### PR TITLE
ci: Add semantic pr commit check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
   semantic-commits-pr-lint:
     name: Run Semantic Commit PR Check
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - name: semantic-pull-request
         uses: amannn/action-semantic-pull-request@v4.5.0


### PR DESCRIPTION
Adds a CI check to ensure all PRs have [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) titles