### PR TITLE
Add activity feed API

### DIFF
--- a/apps/test/package.json
+++ b/apps/test/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "tsx test.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.19.0",
+  "dependencies": {
+    "@package/coder-sdk": "workspace:*",
+    "tsx": "^4.19.2"
+  }
+}

--- a/apps/test/test.ts
+++ b/apps/test/test.ts
@@ -1,0 +1,7 @@
+import { getUsers } from "@package/coder-sdk";
+
+getUsers({auth: "gngkBlBJiO-EWfQshGvf4pmsLCUZmKEKp"}).then((res) => {
+  console.log("blob")
+  console.log(res.response);
+  console.log(res.data?.users);
+});

--- a/apps/test/tsconfig.json
+++ b/apps/test/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/test/turbo.json
+++ b/apps/test/turbo.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "dev": {
+      "dependsOn": ["^build"],
+      "cache": false
+    }
+  }
+}
+

--- a/packages/graphite-demo/server.js
+++ b/packages/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Added a test app for the coder-sdk and created a simple Express server for a graphite demo.

### What changed?

- Created a new test app in the `apps/test` directory that imports and uses the `@package/coder-sdk` to fetch users
- Added necessary configuration files for the test app (package.json, tsconfig.json, turbo.json)
- Created a simple Express server in `packages/graphite-demo/server.js` that serves a mock activity feed

### How to test?

1. For the test app:
   ```
   cd apps/test
   pnpm dev
   ```
   This will run the test script that fetches users using the coder-sdk.

2. For the graphite demo:
   ```
   cd packages/graphite-demo
   node server.js
   ```
   Then navigate to http://localhost:3000/feed to see the mock activity feed data.

### Why make this change?

These additions provide testing capabilities for the coder-sdk and a simple demo server for the graphite component, allowing developers to test functionality in isolation before integrating with the main application.