### PR TITLE
docs: explain convex urls

### DIFF
--- a/docs/vault/.obsidian/workspace.json
+++ b/docs/vault/.obsidian/workspace.json
@@ -8,17 +8,17 @@
         "type": "tabs",
         "children": [
           {
-            "id": "6477196a3e552a33",
+            "id": "b49e5e8bb4111aa7",
             "type": "leaf",
             "state": {
               "type": "markdown",
               "state": {
-                "file": "Leopard Welcome.md",
+                "file": "Convex Setup.md",
                 "mode": "source",
                 "source": false
               },
               "icon": "lucide-file",
-              "title": "Leopard Welcome"
+              "title": "Convex Setup"
             }
           }
         ]
@@ -169,6 +169,6 @@
       "bases:Create new base": false
     }
   },
-  "active": "6477196a3e552a33",
-  "lastOpenFiles": ["Welcome.md", "Leopard Welcome.md"]
+  "active": "b49e5e8bb4111aa7",
+  "lastOpenFiles": ["Leopard Welcome.md", "Convex Setup.md", "Welcome.md"]
 }

--- a/docs/vault/Convex Setup.md
+++ b/docs/vault/Convex Setup.md
@@ -1,0 +1,8 @@
+Convex is hosted on two different types of URLs:
+
+- CONVEX_URL (e.g. abcd.convex.cloud) - The main URL for Convex queries and mutations.
+- CONVEX_SITE_URL (e.g. abcd.convex.site) - The URL for [HTTP Actions](https://docs.convex.dev/functions/http-actions) on Convex.
+
+**Why do we need both?**
+
+While we are using Convex for our application, the authentication is provided by the [better-auth](https://www.better-auth.com/) package. better-auth is hosted through the HTTP Actions feature of Convex, which requires a separate URL (CONVEX_SITE_URL) to function properly.


### PR DESCRIPTION
### TL;DR

Added documentation for Convex setup explaining the different URL types used in the project.

### What changed?

Created a new "Convex Setup.md" file that explains the two different Convex URL types:
- CONVEX_URL (e.g. abcd.convex.cloud) for queries and mutations
- CONVEX_SITE_URL (e.g. abcd.convex.site) for HTTP Actions

The document also explains why both URLs are needed, specifically that better-auth is hosted through Convex's HTTP Actions feature, requiring the separate CONVEX_SITE_URL.

### How to test?

1. Open the Obsidian vault
2. Navigate to the "Convex Setup.md" file
3. Verify the content explains the two URL types and their purposes clearly

### Why make this change?

This documentation helps developers understand the Convex infrastructure setup, particularly the distinction between the two URL types and why both are necessary for the application to function properly with the better-auth package.