### PR TITLE
fix: coder base url

### DIFF
--- a/packages/coder-sdk/openapi-ts.config.ts
+++ b/packages/coder-sdk/openapi-ts.config.ts
@@ -7,11 +7,14 @@ export default defineConfig({
   output: "./src",
   plugins: [
     {
+      name: '@hey-api/client-fetch',
+      baseUrl: `${env.CODER_URL}/api/v2`,
+    },
+    {
       name: '@hey-api/sdk',
       baseUrl: `${env.CODER_URL}/api/v2`,
       auth: true,
 
     }
-    
   ]
 });

--- a/packages/coder-sdk/src/client.gen.ts
+++ b/packages/coder-sdk/src/client.gen.ts
@@ -14,5 +14,5 @@ import type { ClientOptions as ClientOptions2 } from './types.gen';
 export type CreateClientConfig<T extends ClientOptions = ClientOptions2> = (override?: Config<ClientOptions & T>) => Config<Required<ClientOptions> & T>;
 
 export const client = createClient(createConfig<ClientOptions2>({
-    baseUrl: '/api/v2'
+    baseUrl: 'https://coder.nolapse.tech/api/v2'
 }));


### PR DESCRIPTION
### TL;DR

Added client-fetch plugin and updated API base URL configuration.

### What changed?

- Added the `@hey-api/client-fetch` plugin to the OpenAPI TypeScript configuration with the appropriate base URL
- Updated the client's base URL from a relative path (`/api/v2`) to an absolute URL (`https://coder.nolapse.tech/api/v2`)

### How to test?

1. Verify that API requests are correctly routed to `https://coder.nolapse.tech/api/v2`
2. Ensure that both the SDK and client-fetch plugins are working properly with the configured base URLs
3. Test API calls to confirm they're reaching the intended endpoints

### Why make this change?

This change ensures that API requests are directed to the correct absolute URL rather than a relative path, which improves reliability when making requests from different contexts. Adding the client-fetch plugin provides an alternative API client implementation that may offer different features or performance characteristics.