### PR TITLE
fix: use different port for docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "next dev",
+    "dev": "next dev --port 3001",
     "format": "prettier --check . --ignore-path ../.gitignore",
     "start": "next start",
     "postinstall": "fumadocs-mdx"


### PR DESCRIPTION
### TL;DR

Changed the development server port from the default to port 3001.

### What changed?

Updated the `dev` script in the `docs/package.json` file to run Next.js development server on port 3001 instead of the default port (3000).

### How to test?

1. Run `npm run dev` in the docs directory
2. Verify that the development server starts on port 3001
3. Access the documentation site at http://localhost:3001

### Why make this change?

This change allows the documentation server to run on a different port than the default Next.js port (3000), which helps prevent port conflicts when running multiple services simultaneously during development.