### PR TITLE
chore(web): wrap app with convex provider

### DIFF
--- a/apps/nextjs/src/app/layout.tsx
+++ b/apps/nextjs/src/app/layout.tsx
@@ -8,6 +8,8 @@ import { env } from "~/env";
 
 import "~/app/styles.css";
 
+import { ConvexClientProvider } from "~/components/convex-client-provider";
+
 export const metadata: Metadata = {
   metadataBase: new URL(
     env.VERCEL_ENV === "production"
@@ -65,7 +67,9 @@ export default function RootLayout(props: { children: React.ReactNode }) {
           jetbrainsMono.variable,
         )}
       >
-        <ThemeProvider>{props.children}</ThemeProvider>
+        <ConvexClientProvider>
+          <ThemeProvider>{props.children}</ThemeProvider>
+        </ConvexClientProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
### TL;DR

Added Convex client provider to the application root layout.

### What changed?

- Imported the `ConvexClientProvider` component from `~/components/convex-client-provider`
- Wrapped the `ThemeProvider` and its children with the `ConvexClientProvider` in the root layout

### How to test?

1. Run the application and verify it loads correctly
2. Test any Convex-related functionality to ensure data fetching and mutations work properly
3. Verify that the theme functionality continues to work as expected

### Why make this change?

This change ensures that the Convex client is available throughout the application, allowing components to access Convex data and mutations from any part of the component tree. By placing the provider at the root layout level, we establish a single connection to Convex that can be shared across the entire application.