### PR TITLE
feat(auth): cross site secure cookies on trusted domains

### DIFF
--- a/packages/backend/convex/auth.ts
+++ b/packages/backend/convex/auth.ts
@@ -8,7 +8,13 @@ import { components } from "./_generated/api";
 import { DataModel } from "./_generated/dataModel";
 import { query } from "./_generated/server";
 
-const siteUrl = env.SITE_URL;
+const siteUrl = new URL(env.SITE_URL);
+const siteDomainWithoutProtocol = siteUrl.hostname;
+
+const trustedOrigins = [
+  siteDomainWithoutProtocol,
+  `coder.${siteDomainWithoutProtocol}`,
+];
 
 // The component client has methods needed for integrating Convex with Better Auth,
 // as well as helper methods for general use.
@@ -24,7 +30,7 @@ export const createAuth = (
     logger: {
       disabled: optionsOnly,
     },
-    baseURL: siteUrl,
+    baseURL: siteUrl.toString(),
     database: authComponent.adapter(ctx),
     // Configure simple, non-verified email/password to get started
     emailAndPassword: {
@@ -35,6 +41,13 @@ export const createAuth = (
       // The Convex plugin is required for Convex compatibility
       convex(),
     ],
+    advanced: {
+      crossSubDomainCookies: {
+        enabled: true,
+        domain: siteUrl.hostname,
+      },
+    },
+    trustedOrigins: trustedOrigins,
   });
 };
 


### PR DESCRIPTION
### TL;DR

Enable cross-subdomain cookie sharing for authentication between main site and coder subdomain.

### What changed?

- Converted `siteUrl` from a string to a URL object for better parsing
- Added `siteDomainWithoutProtocol` to extract the hostname without protocol
- Created a `trustedOrigins` array that includes both the main domain and `coder.${siteDomainWithoutProtocol}`
- Enabled cross-subdomain cookies in the auth configuration with `crossSubDomainCookies: { enabled: true, domain: siteUrl.hostname }`
- Added the `trustedOrigins` array to the auth configuration

### How to test?

1. Log in on the main site
2. Navigate to the coder subdomain
3. Verify you remain authenticated without needing to log in again
4. Try navigating between the domains to ensure the authentication persists

### Why make this change?

This change allows users to maintain their authentication state when moving between the main site and the coder subdomain. Without this change, users would need to log in separately on each subdomain, creating a disjointed user experience.