### PR TITLE
feat(ui): add pointer-cursor to buttons

### DIFF
--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -5,7 +5,7 @@ import { Slot as SlotPrimitive } from "radix-ui";
 import { cn } from "@package/ui";
 
 export const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {


### PR DESCRIPTION
### TL;DR

Added `cursor-pointer` to the button component's base styles.

### What changed?

Added the `cursor-pointer` CSS class to the button variants in the UI package. This ensures that buttons visually indicate they are clickable elements by showing a pointer cursor on hover.

### How to test?

1. Hover over any button component in the application
2. Verify that the cursor changes to a pointer (hand) icon
3. Check that this behavior is consistent across all button variants

### Why make this change?

This change improves the user experience by providing proper visual feedback when users interact with buttons. The pointer cursor is a standard UI pattern that indicates clickable elements, making the interface more intuitive and accessible.