### PR TITLE
feat(backend): classroom queries and mutations

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as api_coder from "../api/coder.js";
 import type * as api_extension from "../api/extension.js";
 import type * as auth from "../auth.js";
 import type * as http from "../http.js";
+import type * as web_classroom from "../web/classroom.js";
 import type * as web_index from "../web/index.js";
 
 import type {
@@ -25,6 +26,7 @@ declare const fullApi: ApiFromModules<{
   "api/extension": typeof api_extension;
   auth: typeof auth;
   http: typeof http;
+  "web/classroom": typeof web_classroom;
   "web/index": typeof web_index;
 }>;
 

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -15,7 +15,7 @@ export default defineSchema({
   classroomStudentsRelations: defineTable({
     classroomId: v.id("classrooms"),
     studentId: v.string(), // map this to betterAuth user id
-  }),
+  }).index("studentId_classrooms", ["studentId", "classroomId"]),
   events: defineTable({
     changeDetails: v.object({}),
     eventType: v.string(),

--- a/packages/backend/convex/web/classroom.ts
+++ b/packages/backend/convex/web/classroom.ts
@@ -1,0 +1,94 @@
+import { getManyVia } from "convex-helpers/server/relationships";
+import { v } from "convex/values";
+
+import { mutation, query } from "../_generated/server";
+import { authComponent } from "../auth";
+
+export const getEnrolled = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+
+    if (!user) {
+      return [];
+    }
+
+    // lookup classrooms via classroomStudentsRelations
+    const classrooms = await getManyVia(
+      ctx.db,
+      "classroomStudentsRelations",
+      "classroomId",
+      "studentId_classrooms",
+      user._id,
+      "studentId",
+    );
+
+    return classrooms;
+  },
+});
+
+export const getAvailableToEnroll = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+
+    if (!user) {
+      return [];
+    }
+
+    // Get all classrooms
+    const allClassrooms = await ctx.db.query("classrooms").collect();
+
+    // Get enrolled classrooms via relations
+    const classrooms = await getManyVia(
+      ctx.db,
+      "classroomStudentsRelations",
+      "classroomId",
+      "studentId_classrooms",
+      user._id,
+      "studentId",
+    );
+
+    const enrolledClassroomIds = classrooms
+      .filter((c): c is NonNullable<typeof c> => c !== null)
+      .map((c) => c._id);
+
+    // Filter out enrolled classrooms
+    const availableClassrooms = allClassrooms.filter(
+      (classroom) => !enrolledClassroomIds.includes(classroom._id),
+    );
+
+    return availableClassrooms;
+  },
+});
+
+export const enroll = mutation({
+  args: {
+    classroomId: v.id("classrooms"),
+  },
+  handler: async (ctx, args) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+
+    if (!user) {
+      throw new Error("User not authenticated");
+    }
+
+    // Check if already enrolled
+    const existingRelation = await ctx.db
+      .query("classroomStudentsRelations")
+      .withIndex("studentId_classrooms", (q) =>
+        q.eq("studentId", user._id).eq("classroomId", args.classroomId),
+      )
+      .first();
+
+    if (existingRelation) {
+      throw new Error("Already enrolled in this classroom");
+    }
+
+    // Create enrollment relation
+    await ctx.db.insert("classroomStudentsRelations", {
+      classroomId: args.classroomId,
+      studentId: user._id,
+    });
+  },
+});


### PR DESCRIPTION
### TL;DR

Added classroom enrollment functionality for students.

### What changed?

- Created new API endpoints in `web/classroom.js` to handle classroom enrollment:
  - `getEnrolled`: Query to fetch classrooms a student is enrolled in
  - `getAvailableToEnroll`: Query to fetch classrooms available for enrollment
  - `enroll`: Mutation to enroll a student in a classroom
- Added an index `studentId_classrooms` to the `classroomStudentsRelations` table to optimize queries by student ID and classroom ID
- Updated the API definitions to include the new classroom module

### How to test?

1. Log in as a student user
2. Try to view enrolled classrooms (should return an empty array for new users)
3. View available classrooms for enrollment
4. Enroll in a classroom
5. Verify the classroom now appears in the enrolled list
6. Try to enroll in the same classroom again (should throw an error)

### Why make this change?

This change enables students to browse available classrooms and enroll in them, which is a core functionality for the educational platform. The implementation uses Convex's relationship patterns to efficiently track student-classroom relationships and prevent duplicate enrollments.