### PR TITLE
feat(backend): assignment queries and mutations

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as api_coder from "../api/coder.js";
 import type * as api_extension from "../api/extension.js";
 import type * as auth from "../auth.js";
 import type * as http from "../http.js";
+import type * as web_assignment from "../web/assignment.js";
 import type * as web_classroom from "../web/classroom.js";
 import type * as web_index from "../web/index.js";
 
@@ -26,6 +27,7 @@ declare const fullApi: ApiFromModules<{
   "api/extension": typeof api_extension;
   auth: typeof auth;
   http: typeof http;
+  "web/assignment": typeof web_assignment;
   "web/classroom": typeof web_classroom;
   "web/index": typeof web_index;
 }>;

--- a/packages/backend/convex/web/assignment.ts
+++ b/packages/backend/convex/web/assignment.ts
@@ -1,0 +1,28 @@
+import { v } from "convex/values";
+
+import { query } from "../_generated/server";
+import { authComponent } from "../auth";
+
+export const getById = query({
+  args: { id: v.id("assignments") },
+  handler: async (ctx, args) => {
+    const auth = authComponent.getAuthUser(ctx);
+    if (!auth) {
+      throw new Error("Unauthorized");
+    }
+    const assignment = await ctx.db.get(args.id);
+    return assignment;
+  },
+});
+
+export const getByIds = query({
+  args: { ids: v.array(v.id("assignments")) },
+  handler: async (ctx, args) => {
+    const auth = authComponent.getAuthUser(ctx);
+    if (!auth) {
+      throw new Error("Unauthorized");
+    }
+    const assignments = await Promise.all(args.ids.map((id) => ctx.db.get(id)));
+    return assignments.filter(Boolean);
+  },
+});


### PR DESCRIPTION
### TL;DR

Added new assignment query endpoints to fetch assignments by ID and IDs.

### What changed?

- Created a new file `web/assignment.ts` with two query functions:
  - `getById`: Retrieves a single assignment by its ID
  - `getByIds`: Retrieves multiple assignments by an array of IDs
- Updated the generated API types to include the new assignment module

### How to test?

1. Call the `web/assignment:getById` query with a valid assignment ID
2. Call the `web/assignment:getByIds` query with an array of assignment IDs
3. Verify that both endpoints return the expected assignment data

### Why make this change?

To provide dedicated endpoints for retrieving assignment data by ID, making it easier to fetch assignment information for display in the UI or for other operations that need assignment details.