### PR TITLE
feat(web): add basic page to view classroom and assignments

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@convex-dev/better-auth": "0.9.7",
+    "@package/backend": "workspace:*",
     "@package/ui": "workspace:*",
     "@package/validators": "workspace:*",
     "@t3-oss/env-nextjs": "^0.13.8",

--- a/apps/nextjs/src/app/app/page.tsx
+++ b/apps/nextjs/src/app/app/page.tsx
@@ -1,13 +1,183 @@
 "use client";
 
-import { Authenticated, AuthLoading, Unauthenticated } from "convex/react";
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+  useMutation,
+  useQuery,
+} from "convex/react";
+import { toast } from "sonner";
+
+import type { Id } from "@package/backend/convex/_generated/dataModel";
+import { api } from "@package/backend/convex/_generated/api";
+import { cn } from "@package/ui";
+import { Button } from "@package/ui/button";
+import { Separator } from "@package/ui/separator";
+
+function AssignmentItem({
+  assignmentId,
+  isLast = false,
+}: {
+  assignmentId: Id<"assignments">;
+  isLast?: boolean;
+}) {
+  const assignment = useQuery(api.web.assignment.getById, { id: assignmentId });
+
+  if (!assignment) return null;
+
+  return (
+    <div className={cn("border-t py-4 text-sm", isLast && "border-b")}>
+      <div className="font-medium">{assignment.name}</div>
+      <div className="text-muted-foreground text-xs">
+        Due: {new Date(assignment.dueDate).toLocaleDateString()}
+      </div>
+    </div>
+  );
+}
+
+function Content() {
+  const enrolledClassrooms = useQuery(api.web.classroom.getEnrolled);
+  const classroomsAvailableToEnroll = useQuery(
+    api.web.classroom.getAvailableToEnroll,
+  );
+  const enroll = useMutation(api.web.classroom.enroll);
+
+  const handleEnroll = async (classroomId: Id<"classrooms">) => {
+    try {
+      await enroll({ classroomId });
+    } catch (error) {
+      toast.error("Failed to enroll in classroom.");
+      console.error(error);
+    }
+  };
+
+  return (
+    <div className="container mx-auto space-y-12 p-6">
+      {/* Enrolled Classrooms */}
+      <section>
+        <h2 className="mb-6 text-2xl font-bold">My Classrooms</h2>
+        {enrolledClassrooms && enrolledClassrooms.length > 0 ? (
+          <div className="space-y-6">
+            {enrolledClassrooms
+              .filter(
+                (classroom): classroom is NonNullable<typeof classroom> =>
+                  classroom !== null,
+              )
+              .sort((a, b) => b.assignments.length - a.assignments.length)
+              .map((classroom) => (
+                <div key={classroom._id}>
+                  <div className="flex flex-col gap-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <h3 className="text-lg font-semibold">
+                          {classroom.className}
+                        </h3>
+                        <p className="text-muted-foreground text-sm">
+                          Enrolled classroom
+                        </p>
+                      </div>
+                      <span className="text-muted-foreground text-sm">
+                        {classroom.assignments.length} assignments
+                      </span>
+                    </div>
+                    {classroom.assignments.length > 0 && (
+                      <div className="flex flex-col gap-2">
+                        <h4 className="text-muted-foreground text-sm font-medium">
+                          Assignments:
+                        </h4>
+                        <div className="flex flex-col">
+                          {classroom.assignments.map((assignmentId, index) => (
+                            <AssignmentItem
+                              key={assignmentId}
+                              assignmentId={assignmentId}
+                              isLast={
+                                index === classroom.assignments.length - 1
+                              }
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground">No enrolled classrooms yet.</p>
+        )}
+      </section>
+
+      {/* Available Classrooms */}
+      {classroomsAvailableToEnroll &&
+        classroomsAvailableToEnroll.length > 0 && (
+          <>
+            <section>
+              <h2 className="mb-6 text-2xl font-bold">Available Classrooms</h2>
+              <div className="space-y-6">
+                {classroomsAvailableToEnroll.map((classroom, index) => (
+                  <div key={classroom._id}>
+                    <div className="space-y-4">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <h3 className="text-lg font-semibold">
+                            {classroom.className}
+                          </h3>
+                          <p className="text-muted-foreground text-sm">
+                            Available for enrollment
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-4">
+                          <span className="text-muted-foreground text-sm">
+                            {classroom.assignments.length} assignments
+                          </span>
+                          <Button
+                            onClick={() => handleEnroll(classroom._id)}
+                            size="sm"
+                          >
+                            Enroll
+                          </Button>
+                        </div>
+                      </div>
+                      {classroom.assignments.length > 0 && (
+                        <div className="ml-4 space-y-2">
+                          <h4 className="text-muted-foreground text-sm font-medium">
+                            Assignments:
+                          </h4>
+                          <div className="space-y-2">
+                            {classroom.assignments.map((assignmentId) => (
+                              <AssignmentItem
+                                key={assignmentId}
+                                assignmentId={assignmentId}
+                              />
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                    {index < classroomsAvailableToEnroll.length - 1 && (
+                      <Separator className="mt-6" />
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          </>
+        )}
+    </div>
+  );
+}
 
 export default function Page() {
   return (
     <main>
       <Unauthenticated>Logged out</Unauthenticated>
-      <Authenticated>Logged in</Authenticated>
-      <AuthLoading>Loading...</AuthLoading>
+      <Authenticated>
+        <Content />
+      </Authenticated>
+      <AuthLoading>
+        <div className="p-8">Loading...</div>
+      </AuthLoading>
     </main>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@convex-dev/better-auth':
         specifier: 0.9.7
         version: 0.9.7(@standard-schema/spec@1.0.0)(better-auth@1.3.27(next@16.0.0(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(convex@1.29.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.3)
+      '@package/backend':
+        specifier: workspace:*
+        version: link:../../packages/backend
       '@package/ui':
         specifier: workspace:*
         version: link:../../packages/ui


### PR DESCRIPTION
### TL;DR

Implemented classroom dashboard with enrollment functionality in the app page.

### What changed?

- Added `@package/backend` dependency to the NextJS app
- Completely redesigned the app page to display:
  - User's enrolled classrooms with their assignments
  - Available classrooms that users can enroll in
- Implemented classroom enrollment functionality with a button to join new classrooms
- Added assignment display components that show name and due date
- Enhanced the authentication loading state

### How to test?

1. Log in to the application
2. Verify that enrolled classrooms appear in the "My Classrooms" section
3. Check that available classrooms appear in the "Available Classrooms" section
4. Try enrolling in a new classroom by clicking the "Enroll" button
5. Confirm that assignments display correctly with their names and due dates

### Why make this change?

This change provides the core classroom management functionality for the application, allowing users to view their enrolled classrooms, see assignments with due dates, and discover and join new classrooms. It creates the main dashboard experience that students will use to manage their educational content.