### PR TITLE
ci: add next-build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,21 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+  next-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup
+        uses: ./tooling/github/setup
+
+      - name: Copy env
+        shell: bash
+        run: cp apps/nextjs/.env.example apps/nextjs/.env
+
+      - name: Build
+        run: pnpm turbo run build -F @package/nextjs
+
   semantic-commits-pr-lint:
     name: Run Semantic Commit PR Check
     runs-on: ubuntu-latest

--- a/apps/nextjs/.env.example
+++ b/apps/nextjs/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_CONVEX_URL="https://sample.convex.cloud"
+NEXT_PUBLIC_CONVEX_SITE_URL="https://sample.convex.site"

--- a/apps/nextjs/src/env.ts
+++ b/apps/nextjs/src/env.ts
@@ -55,5 +55,5 @@ function getConvexSiteUrl() {
     process.env.NEXT_PUBLIC_CONVEX_SITE_URL = derivedSiteUrl;
     return derivedSiteUrl;
   }
-  throw new Error("CONVEX_SITE_URL is not defined");
+  throw new Error("NEXT_PUBLIC_CONVEX_SITE_URL is not defined");
 }


### PR DESCRIPTION
### TL;DR

Added a Next.js build step to CI workflow and included environment configuration example.

### What changed?

- Added a new `next-build` job to the GitHub Actions CI workflow that:
  - Checks out the repository
  - Sets up the environment
  - Copies the example environment file to `.env`
  - Runs the build command
- Created a new `.env.example` file in the `apps/nextjs` directory with placeholders for Convex URL configuration variables

### How to test?

1. Verify the CI workflow runs successfully with the new build step
2. Confirm that new contributors can use the `.env.example` file as a template for their local environment setup
3. Check that the build process correctly uses the environment variables

### Why make this change?

This change ensures that builds are tested in the CI pipeline, catching potential build failures before they reach production. The addition of the environment example file helps new developers get started quickly by providing the required configuration variables.