### PR TITLE
feat(extension): use environment variables and turborepo

### DIFF
--- a/apps/vscode-extension/.env.example
+++ b/apps/vscode-extension/.env.example
@@ -1,0 +1,1 @@
+CONVEX_URL=https://example.convex.cloud

--- a/apps/vscode-extension/.vscode/launch.json
+++ b/apps/vscode-extension/.vscode/launch.json
@@ -3,19 +3,16 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"name": "Run Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
-			],
-			"outFiles": [
-				"${workspaceFolder}/dist/**/*.js"
-			],
-			"preLaunchTask": "${defaultBuildTask}"
-		}
-	]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "preLaunchTask": "${defaultBuildTask}",
+      "envFile": "${workspaceFolder}/.env"
+    },
+  ]
 }

--- a/apps/vscode-extension/.vscodeignore
+++ b/apps/vscode-extension/.vscodeignore
@@ -7,6 +7,7 @@ src/**
 .yarnrc
 esbuild.js
 vsc-extension-quickstart.md
+.env
 **/tsconfig.json
 **/eslint.config.mjs
 **/*.map

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -38,7 +38,8 @@
     "@package/prettier-config": "workspace:*",
     "@package/validators": "workspace:*",
     "@t3-oss/env-core": "^0.13.8",
-    "convex": "^1.29.0"
+    "convex": "^1.29.0",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@package/eslint-config": "workspace:*",

--- a/apps/vscode-extension/src/env.ts
+++ b/apps/vscode-extension/src/env.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  CONVEX_URL: z.string(),
+});
+
+export const env = envSchema.parse(process.env);

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -6,6 +6,8 @@ import * as vscode from "vscode";
 import { api } from "@package/backend/convex/_generated/api";
 import { workspaceEventName } from "@package/validators";
 
+import { env } from "./env";
+
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -13,7 +15,7 @@ export function activate(context: vscode.ExtensionContext) {
   // This line of code will only be executed once when your extension is activated
   console.log('Congratulations, your extension "leopard" is now active!');
   const channel = vscode.window.createOutputChannel("eventlogger");
-  const client = new ConvexHttpClient("https://tough-gazelle-941.convex.cloud");
+  const client = new ConvexHttpClient(env.CONVEX_URL);
 
   function timestamp() {
     return Date.now();

--- a/apps/vscode-extension/turbo.json
+++ b/apps/vscode-extension/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "env": ["CONVEX_URL"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       convex:
         specifier: ^1.29.0
         version: 1.29.0(react@19.2.0)
+      zod:
+        specifier: 'catalog:'
+        version: 4.1.12
     devDependencies:
       '@package/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
### TL;DR

Added environment variable support to the VS Code extension to configure the Convex URL.

### What changed?

- Added `.env.example` file with a template for the `CONVEX_URL` environment variable
- Created an environment validation system using Zod in a new `env.ts` file
- Updated the extension to use the environment variable instead of a hardcoded Convex URL
- Modified the VS Code launch configuration to load environment variables from `.env`
- Added `.env` to `.vscodeignore` to prevent it from being included in the extension package
- Added `zod` dependency to the package.json
- Created a turbo.json configuration to include the CONVEX_URL in the build environment

### How to test?

1. Copy `.env.example` to `.env` and set your Convex URL
2. Launch the extension in debug mode
3. Verify that the extension connects to the specified Convex URL instead of the hardcoded one

### Why make this change?

This change makes the extension more configurable by removing the hardcoded Convex URL. It allows developers to point the extension to different Convex deployments without modifying the code, which is especially useful for development, testing, and production environments.