### PR TITLE
docs: remove FUNDING template file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: juliusmarminge


### PR DESCRIPTION
### TL;DR

Removed GitHub Sponsors configuration file from the create-t3-turbo template.

