### PR TITLE
test: bootstrap Next.js UI component tests

### DIFF
--- a/apps/nextjs/eslint.config.ts
+++ b/apps/nextjs/eslint.config.ts
@@ -12,4 +12,28 @@ export default defineConfig(
   reactConfig,
   nextjsConfig,
   restrictEnvAccess,
+  {
+    files: ["src/**/*.ts", "src/**/*.tsx"],
+    ignores: ["src/lib/auth.tsx", "src/test/**"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "convex/react",
+              importNames: [
+                "Authenticated",
+                "Unauthenticated",
+                "AuthLoading",
+                "useConvexAuth",
+              ],
+              message:
+                "Import from '~/lib/auth' instead to enable proper test mocking.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 );

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -9,6 +9,8 @@
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint --flag unstable_native_nodejs_ts_config",
     "start": "pnpm with-env next start",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "with-env": "dotenv -e ../../.env -e ./.env --"
   },
@@ -23,7 +25,6 @@
     "convex": "^1.29.0",
     "next": "16.0.10",
     "react": "catalog:react19",
-    "react-dom": "catalog:react19",
     "react-scrubber": "^2.1.0",
     "react-shiki": "^0.9.0",
     "sonner": "^2.0.7",
@@ -34,15 +35,23 @@
     "@package/prettier-config": "workspace:*",
     "@package/tailwind-config": "workspace:*",
     "@package/tsconfig": "workspace:*",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "catalog:",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
+    "@vitejs/plugin-react": "catalog:",
     "eslint": "catalog:",
     "jiti": "^2.5.1",
+    "jsdom": "^27.4.0",
     "prettier": "catalog:",
+    "react-dom": "^19.1.1",
     "tailwindcss": "catalog:",
     "tw-animate-css": "^1.4.0",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "^4.0.17"
   },
   "prettier": "@package/prettier-config"
 }

--- a/apps/nextjs/src/app/app/page.tsx
+++ b/apps/nextjs/src/app/app/page.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { startTransition, useActionState, useEffect } from "react";
-import {
-  Authenticated,
-  AuthLoading,
-  Unauthenticated,
-  useMutation,
-  useQuery,
-} from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
 
 import type { Id } from "@package/backend/convex/_generated/dataModel";
@@ -17,6 +11,7 @@ import { Button } from "@package/ui/button";
 import { Separator } from "@package/ui/separator";
 import { Spinner } from "@package/ui/spinner";
 
+import { Authenticated, AuthLoading, Unauthenticated } from "~/lib/auth";
 import { launchWorkspace } from "./actions";
 
 function AssignmentItem({

--- a/apps/nextjs/src/components/header-auth.test.tsx
+++ b/apps/nextjs/src/components/header-auth.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  Authenticated,
+  AuthLoading,
+  ConvexAuthTestProvider,
+  Unauthenticated,
+  useConvexAuth,
+} from "~/test/convex-auth-test-provider";
+import HeaderAuth from "./header-auth";
+
+vi.mock("~/lib/auth", () => ({
+  Authenticated,
+  Unauthenticated,
+  AuthLoading,
+  useConvexAuth,
+}));
+
+describe("HeaderAuth", () => {
+  describe("when authenticated", () => {
+    it("renders sign out and go to app buttons", () => {
+      render(
+        <ConvexAuthTestProvider isAuthenticated={true}>
+          <HeaderAuth />
+        </ConvexAuthTestProvider>,
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Sign Out" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Go to App" }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render sign in button", () => {
+      render(
+        <ConvexAuthTestProvider isAuthenticated={true}>
+          <HeaderAuth />
+        </ConvexAuthTestProvider>,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Sign In" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("links to correct routes", () => {
+      render(
+        <ConvexAuthTestProvider isAuthenticated={true}>
+          <HeaderAuth />
+        </ConvexAuthTestProvider>,
+      );
+
+      expect(screen.getByRole("link", { name: "Sign Out" })).toHaveAttribute(
+        "href",
+        "/auth/sign-out",
+      );
+      expect(screen.getByRole("link", { name: "Go to App" })).toHaveAttribute(
+        "href",
+        "/app",
+      );
+    });
+  });
+
+  describe("when unauthenticated", () => {
+    it("renders sign in button", () => {
+      render(
+        <ConvexAuthTestProvider isAuthenticated={false}>
+          <HeaderAuth />
+        </ConvexAuthTestProvider>,
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Sign In" }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render sign out or go to app buttons", () => {
+      render(
+        <ConvexAuthTestProvider isAuthenticated={false}>
+          <HeaderAuth />
+        </ConvexAuthTestProvider>,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Sign Out" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Go to App" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("links sign in to correct route", () => {
+      render(
+        <ConvexAuthTestProvider isAuthenticated={false}>
+          <HeaderAuth />
+        </ConvexAuthTestProvider>,
+      );
+
+      expect(screen.getByRole("link", { name: "Sign In" })).toHaveAttribute(
+        "href",
+        "/auth/sign-in",
+      );
+    });
+  });
+
+  describe("when loading", () => {
+    it("renders nothing", () => {
+      render(
+        <ConvexAuthTestProvider isLoading={true}>
+          <HeaderAuth />
+        </ConvexAuthTestProvider>,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Sign In" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Sign Out" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Go to App" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/nextjs/src/components/header-auth.tsx
+++ b/apps/nextjs/src/components/header-auth.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { Authenticated, Unauthenticated } from "convex/react";
 
 import { Button } from "@package/ui/button";
+
+import { Authenticated, Unauthenticated } from "~/lib/auth";
 
 function HeaderAuth() {
   return (

--- a/apps/nextjs/src/lib/auth.tsx
+++ b/apps/nextjs/src/lib/auth.tsx
@@ -1,0 +1,8 @@
+export {
+  Authenticated,
+  Unauthenticated,
+  AuthLoading,
+  useConvexAuth,
+} from "convex/react";
+
+export type { ConvexAuthState } from "convex/react";

--- a/apps/nextjs/src/test/convex-auth-test-provider.tsx
+++ b/apps/nextjs/src/test/convex-auth-test-provider.tsx
@@ -1,0 +1,79 @@
+import type { ConvexAuthState } from "convex/react";
+import type { ReactNode } from "react";
+import { createContext, useContext } from "react";
+
+const ConvexAuthTestContext = createContext<ConvexAuthState | undefined>(
+  undefined,
+);
+
+export interface ConvexAuthTestProviderProps {
+  children: ReactNode;
+  isLoading?: boolean;
+  isAuthenticated?: boolean;
+}
+
+/**
+ * Test provider that mocks the Convex auth context.
+ * Use this to wrap components that depend on Convex auth state in tests.
+ */
+export function ConvexAuthTestProvider({
+  children,
+  isLoading = false,
+  isAuthenticated = false,
+}: ConvexAuthTestProviderProps) {
+  return (
+    <ConvexAuthTestContext.Provider value={{ isLoading, isAuthenticated }}>
+      {children}
+    </ConvexAuthTestContext.Provider>
+  );
+}
+
+/**
+ * Test version of useConvexAuth that reads from ConvexAuthTestProvider.
+ * Mock convex/react's useConvexAuth with this in your tests.
+ */
+export function useConvexAuth(): ConvexAuthState {
+  const context = useContext(ConvexAuthTestContext);
+  if (context === undefined) {
+    throw new Error(
+      "useConvexAuth must be used within a ConvexAuthTestProvider in tests",
+    );
+  }
+  return context;
+}
+
+/**
+ * Test version of Authenticated component.
+ * Mirrors the real Convex implementation but uses the test context.
+ */
+export function Authenticated({ children }: { children: ReactNode }) {
+  const { isLoading, isAuthenticated } = useConvexAuth();
+  if (isLoading || !isAuthenticated) {
+    return null;
+  }
+  return <>{children}</>;
+}
+
+/**
+ * Test version of Unauthenticated component.
+ * Mirrors the real Convex implementation but uses the test context.
+ */
+export function Unauthenticated({ children }: { children: ReactNode }) {
+  const { isLoading, isAuthenticated } = useConvexAuth();
+  if (isLoading || isAuthenticated) {
+    return null;
+  }
+  return <>{children}</>;
+}
+
+/**
+ * Test version of AuthLoading component.
+ * Mirrors the real Convex implementation but uses the test context.
+ */
+export function AuthLoading({ children }: { children: ReactNode }) {
+  const { isLoading } = useConvexAuth();
+  if (!isLoading) {
+    return null;
+  }
+  return <>{children}</>;
+}

--- a/apps/nextjs/vitest.config.ts
+++ b/apps/nextjs/vitest.config.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "~": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["src/**/*.test.{ts,tsx}"],
+    setupFiles: ["./vitest.setup.ts"],
+  },
+});

--- a/apps/nextjs/vitest.setup.ts
+++ b/apps/nextjs/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,7 +53,7 @@
     "jsdom": "^27.4.0",
     "prettier": "catalog:",
     "react": "catalog:react19",
-    "react-dom": "19.1.1",
+    "react-dom": "catalog:react19",
     "typescript": "catalog:",
     "vitest": "^4.0.17",
     "zod": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
     dependencies:
       '@convex-dev/better-auth':
         specifier: 0.9.7
-        version: 0.9.7(@standard-schema/spec@1.0.0)(better-auth@1.3.27(next@16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(convex@1.29.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.3)
+        version: 0.9.7(@standard-schema/spec@1.0.0)(better-auth@1.3.27(next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(convex@1.29.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.3)
       '@package/backend':
         specifier: workspace:*
         version: link:../../packages/backend
@@ -111,19 +111,16 @@ importers:
         version: 1.25.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       better-auth:
         specifier: 1.3.27
-        version: 1.3.27(next@16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 1.3.27(next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       convex:
         specifier: ^1.29.0
         version: 1.29.0(react@19.1.1)
       next:
         specifier: 16.0.10
-        version: 16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react:
         specifier: catalog:react19
         version: 19.1.1
-      react-dom:
-        specifier: catalog:react19
-        version: 19.1.1(react@19.1.1)
       react-scrubber:
         specifier: ^2.1.0
         version: 2.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -149,6 +146,18 @@ importers:
       '@package/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/typescript
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.1
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: 'catalog:'
         version: 22.18.12
@@ -158,15 +167,24 @@ importers:
       '@types/react-dom':
         specifier: catalog:react19
         version: 19.2.3(@types/react@19.2.4)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 5.1.0(vite@7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2))
       eslint:
         specifier: 'catalog:'
         version: 9.39.1(jiti@2.6.1)
       jiti:
         specifier: ^2.5.1
         version: 2.6.1
+      jsdom:
+        specifier: ^27.4.0
+        version: 27.4.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.1.1(react@19.1.1)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.16
@@ -176,6 +194,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.17
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@22.18.12)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)
 
   apps/vscode-extension:
     dependencies:
@@ -410,7 +431,7 @@ importers:
         specifier: catalog:react19
         version: 19.1.1
       react-dom:
-        specifier: 19.1.1
+        specifier: catalog:react19
         version: 19.1.1(react@19.1.1)
       typescript:
         specifier: 'catalog:'
@@ -5149,7 +5170,6 @@ packages:
   next@16.0.10:
     resolution: {integrity: sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA==}
     engines: {node: '>=20.9.0'}
-    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -6834,9 +6854,9 @@ snapshots:
 
   '@better-fetch/fetch@1.1.18': {}
 
-  '@convex-dev/better-auth@0.9.7(@standard-schema/spec@1.0.0)(better-auth@1.3.27(next@16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(convex@1.29.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.3)':
+  '@convex-dev/better-auth@0.9.7(@standard-schema/spec@1.0.0)(better-auth@1.3.27(next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(convex@1.29.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.3)':
     dependencies:
-      better-auth: 1.3.27(next@16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      better-auth: 1.3.27(next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       common-tags: 1.8.2
       convex: 1.29.0(react@19.1.1)
       convex-helpers: 0.1.105(@standard-schema/spec@1.0.0)(convex@1.29.0(react@19.1.1))(react@19.1.1)(typescript@5.9.3)(zod@3.25.76)
@@ -9334,6 +9354,18 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vitejs/plugin-react@5.1.0(vite@7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@rolldown/pluginutils': 1.0.0-beta.43
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitejs/plugin-react@5.1.0(vite@7.1.12(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       '@babel/core': 7.28.5
@@ -9354,6 +9386,14 @@ snapshots:
       '@vitest/utils': 4.0.17
       chai: 6.2.2
       tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.17(vite@7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@vitest/spy': 4.0.17
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)
 
   '@vitest/mocker@4.0.17(vite@7.1.12(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
@@ -9631,7 +9671,7 @@ snapshots:
 
   basic-ftp@5.0.5: {}
 
-  better-auth@1.3.27(next@16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  better-auth@1.3.27(next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@better-auth/core': 1.3.27
       '@better-auth/utils': 0.3.0
@@ -9647,7 +9687,7 @@ snapshots:
       nanostores: 1.0.1
       zod: 4.1.12
     optionalDependencies:
-      next: 16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
@@ -12125,7 +12165,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  next@16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@next/env': 16.0.10
       '@swc/helpers': 0.5.15
@@ -12133,7 +12173,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      styled-jsx: 5.1.6(react@19.1.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.1.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.0.10
       '@next/swc-darwin-x64': 16.0.10
@@ -13361,10 +13401,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.6
 
-  styled-jsx@5.1.6(react@19.1.1):
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.1.1):
     dependencies:
       client-only: 0.0.1
       react: 19.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.5
 
   styled-jsx@5.1.6(react@19.2.0):
     dependencies:
@@ -13724,6 +13766,20 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.55.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.18.12
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+
   vite@7.1.12(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2):
     dependencies:
       esbuild: 0.25.12
@@ -13737,6 +13793,45 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
+
+  vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@22.18.12)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2):
+    dependencies:
+      '@vitest/expect': 4.0.17
+      '@vitest/mocker': 4.0.17(vite@7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/pretty-format': 4.0.17
+      '@vitest/runner': 4.0.17
+      '@vitest/snapshot': 4.0.17
+      '@vitest/spy': 4.0.17
+      '@vitest/utils': 4.0.17
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.18.12
+      jsdom: 27.4.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2):
     dependencies:


### PR DESCRIPTION
### TL;DR

Added React testing infrastructure with Vitest and Testing Library, including a test for the HeaderAuth component.

### What changed?

- Set up Vitest with React testing configuration
- Added test dependencies (Testing Library, jsdom, etc.)
- Created a test for the HeaderAuth component
- Implemented a ConvexAuthTestProvider for mocking Convex auth in tests
- Added a centralized auth export in `~/lib/auth.tsx` to facilitate testing
- Updated imports to use the new auth module instead of directly from convex/react
- Added ESLint rule to enforce using the centralized auth module
- Added test scripts to package.json

### How to test?

1. Run the tests with `pnpm test` or `pnpm test:watch`
2. Verify the HeaderAuth component tests pass
3. Try creating a new test for another component using the ConvexAuthTestProvider

### Why make this change?

This change improves the testability of components that rely on Convex authentication by providing a consistent way to mock the auth state in tests. By centralizing auth-related imports through a single module, we can easily mock the authentication state without modifying the components themselves. This approach makes tests more reliable and easier to write, while ensuring components behave correctly in different authentication states.

Closes #78 