### PR TITLE
feat(extension): DID_CHANGE_TEXT_DOCUMENT data ingestion implementation

### DIFF
--- a/packages/backend/convex/api/extension.ts
+++ b/packages/backend/convex/api/extension.ts
@@ -39,12 +39,11 @@ export const addBatchedChangesMutation = mutation({
     //   return;
     // }
 
+    // TODO: implement workspace session retrieval flow
     for (const change of args.changes) {
       const newEvent: WithoutSystemFields<Doc<"events">> = {
-        eventType: change.eventType,
-        timestamp: change.timestamp,
-        workspaceId: "ks74y4q2sn8x2t0t31nq5cb32s7vvjy5" as Id<"workspaces">, //workspace._id,
-        metadata: change.metadata,
+        workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf" as Id<"workspaces">, //workspace._id,
+        ...change,
       };
       const eventId = await ctx.db.insert("events", newEvent);
       insertedIds.push(eventId);

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -6,6 +6,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./src/index.ts"
+    },
+    "./workspaceEvents": {
+      "types": "./dist/workspaceEvents.d.ts",
+      "default": "./src/workspaceEvents.ts"
     }
   },
   "license": "MIT",

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -6,19 +6,3 @@ export const unused = z.string().describe(
    with back and frontend, you can put them in here
   `,
 );
-
-export const workspaceEventName = z.enum([
-  "DID_OPEN_TEXT_DOCUMENT",
-  "DID_CLOSE_TEXT_DOCUMENT",
-  "DID_CREATE_FILES",
-  "DID_DELETE_FILES",
-  "DID_RENAME_FILES",
-  "DID_CHANGE_FILES",
-  "DID_SAVE_TEXT_DOCUMENT",
-  "DID_CHANGE_TEXT_DOCUMENT",
-  "DID_CHANGE_TEXT_EDITOR_SELECTION",
-  "DID_CHANGE_TERMINAL_STATE",
-  "DID_END_TERMINAL_SHELL_EXECUTION",
-]);
-
-export type WorkspaceEventName = z.infer<typeof workspaceEventName>;

--- a/packages/validators/src/workspaceEvents.ts
+++ b/packages/validators/src/workspaceEvents.ts
@@ -1,0 +1,44 @@
+/**
+ * Module for validating database queries on workspace events.
+ */
+
+import { z } from "zod";
+
+export const NAMES = ["DID_CHANGE_TEXT_DOCUMENT"] as const;
+
+export const NAME = NAMES.reduce(
+  (acc, name) => {
+    acc[name] = name;
+    return acc;
+  },
+  {} as Record<(typeof NAMES)[number], (typeof NAMES)[number]>,
+);
+
+const Event = z.object({
+  timestamp: z.number(),
+  workspaceId: z.string(),
+});
+
+export const DidChangeTextDocument = Event.extend({
+  eventType: z.literal("DID_CHANGE_TEXT_DOCUMENT"),
+  metadata: z.object({
+    contentChanges: z.array(
+      z.object({
+        range: z.object({
+          start: z.object({
+            line: z.number(),
+            column: z.number(),
+          }),
+          end: z.object({
+            line: z.number(),
+            column: z.number(),
+          }),
+        }),
+        text: z.string(),
+        filePath: z.string(),
+      }),
+    ),
+  }),
+});
+
+export type DidChangeTextDocument = z.infer<typeof DidChangeTextDocument>;


### PR DESCRIPTION
## TL;DR

Implemented reliable data uploading for the `DID_CHANGE_TEXT_DOCUMENT` event in the VS Code extension, transitioning from unstructured metadata to a strictly validated event schema<sup>1</sup><sup>1</sup><sup>1</sup><sup>1</sup>.

## What changed?

- **VS Code Extension**:
    - Updated the `onDidChangeTextDocument` listener to capture and upload detailed `contentChanges` (including range, text, and file path) instead of full document content<sup>2</sup><sup>2</sup><sup>2</sup><sup>2</sup>.
    - Cleaned up unused listeners for file creation, deletion, renaming, and document saving to focus on core text change tracking<sup>3</sup>.
    - Enhanced error reporting to display a VS Code information message when uploading fails<sup>4</sup>.
- **Backend & Schema**:
    - Renamed `metadata` field to `data` in the `events` table and associated Convex mutations/queries for better consistency<sup>5</sup><sup>5</sup><sup>5</sup><sup>5</sup>.
    - Updated the `addBatchedChangesMutation` to support the new event structure and added a placeholder for workspace session retrieval<sup>6</sup>.
- **Validation**:
    - Introduced `packages/validators/src/workspaceEvents.ts` with a strict Zod schema for `DID_CHANGE_TEXT_DOCUMENT` events, ensuring data integrity across the stack<sup>7</sup><sup>7</sup><sup>7</sup><sup>7</sup>.
    - Exported new validator modules in `package.json` for easier consumption by other packages<sup>8</sup>.

## How to test?

1. **Extension Data Capture**: Launch the VS Code extension and modify a file. Check the Convex dashboard or logs to ensure `contentChanges` are being uploaded with the correct range and text data<sup>9</sup><sup>9</sup><sup>9</sup>.
2. **Schema Validation**: Verify that the backend successfully parses the uploaded events using the new `DidChangeTextDocument` Zod schema<sup>10</sup><sup>10</sup>.
3. **Error Handling**: Temporarily disconnect the network or point the extension to an invalid API endpoint to confirm that the "Error, failed to upload" message appears in VS Code<sup>11</sup>.

## Why make this change?

This change is essential for supporting dynamic text replay. By moving away from uploading the entire file content on every change and instead capturing incremental `contentChanges`, we significantly reduce bandwidth and storage requirements<sup>12</sup>. The introduction of strict validation ensures that the replay engine can reliably process these changes without encountering malformed data<sup>13</sup><sup>13</sup><sup>13</sup><sup>13</sup>.  
  
resolves #82