### PR TITLE
test: add integration test to check prod coder version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,4 +24,6 @@ SITE_URL='http://localhost:3000'
 AUTH_DISCORD_ID=''
 AUTH_DISCORD_SECRET=''
 
-CODER_URL='http://example.com/'
+# This is being weird on github and overwriting the env variable i set. I'm just gonna put it here for now
+# Since this is not secret that needs to be hidden. 
+CODER_URL='https://coder.nolapse.tech/'

--- a/packages/coder-sdk/package.json
+++ b/packages/coder-sdk/package.json
@@ -16,7 +16,9 @@
   "scripts": {
     "generate": "dotenv -e ../../.env -e ../../.env.local -- openapi-ts",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "dotenv -e ../../.env -e ../../.env.local -- vitest run",
+    "test:watch": "dotenv -e ../../.env -e ../../.env.local -- vitest"
   },
   "dependencies": {
     "@t3-oss/env-core": "^0.13.8",
@@ -26,6 +28,7 @@
     "@hey-api/openapi-ts": "^0.87.3",
     "@package/tsconfig": "workspace:*",
     "@types/node": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "^4.0.17"
   }
 }

--- a/packages/coder-sdk/src/coder.integration.test.ts
+++ b/packages/coder-sdk/src/coder.integration.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { buildInfo } from "./sdk.gen";
+import { createClient, createConfig } from "./client";
+
+describe("Coder integration tests", () => {
+  let client: ReturnType<typeof createClient>;
+
+  beforeAll(() => {
+    const coderUrl = process.env.CODER_URL;
+    if (!coderUrl) {
+      throw new Error("CODER_URL environment variable is required for integration tests");
+    }
+    client = createClient(createConfig({
+      baseUrl: `${coderUrl}/api/v2`,
+    }));
+  });
+
+  it("should check if the production version of coder matches local schema version", async () => {
+    const response = await buildInfo({ client });
+
+    expect(response).toBeDefined();
+    expect(response.data).toBeDefined();
+    expect(response.data?.version).toMatch(/^v2\.28\.0/);
+    expect(response.data?.agent_api_version).toBeDefined();
+    expect(response.data?.dashboard_url).toBeDefined();
+  });
+});

--- a/packages/coder-sdk/vitest.config.ts
+++ b/packages/coder-sdk/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.test.{ts,tsx}", "src/**/*.integration.test.{ts,tsx}"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.17
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@22.18.12)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)
 
   packages/ui:
     dependencies:


### PR DESCRIPTION
### TL;DR

Added integration testing capabilities to the coder-sdk package.

### What changed?

- Added test scripts to the coder-sdk package.json for running tests with vitest
- Created a new integration test file that verifies connectivity with the Coder API
- Added a vitest configuration file to properly set up the test environment
- Added vitest as a dependency to the package

### How to test?

1. Run `pnpm run test` to execute the integration tests
2. Ensure you have the CODER_URL environment variable set in your .env file
3. Verify that the test successfully connects to the Coder API and checks the version

### Why make this change?

This change introduces integration testing for the coder-sdk package to ensure it properly communicates with the Coder API. The test verifies that the SDK can connect to the API and that the version information matches expectations, which helps prevent regressions and ensures compatibility with the Coder backend.