### PR TITLE
fix(extension): remove duplicate event listeners

### DIFF
--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -64,42 +64,6 @@ export function activate(context: vscode.ExtensionContext) {
   // );
 
   context.subscriptions.push(
-    vscode.workspace.onDidCloseTextDocument((e) => {
-      channel.appendLine(`[${timestamp()}] ${e.uri.fsPath} - closed`);
-    }),
-  );
-
-  context.subscriptions.push(
-    vscode.workspace.onDidCreateFiles((e) => {
-      channel.appendLine(
-        `[${timestamp()}] ${e.files.map((file) => file.fsPath).join(", ")} - created`,
-      );
-    }),
-  );
-
-  context.subscriptions.push(
-    vscode.workspace.onDidDeleteFiles((e) => {
-      channel.appendLine(
-        `[${timestamp()}] ${e.files.map((file) => file.fsPath).join(", ")} - deleted`,
-      );
-    }),
-  );
-
-  context.subscriptions.push(
-    vscode.workspace.onDidRenameFiles((e) => {
-      channel.appendLine(
-        `[${timestamp()}] ${e.files.map((file) => file.oldUri.fsPath).join(", ")} - ${e.files.map((file) => file.newUri.fsPath).join(", ")} - renamed`,
-      );
-    }),
-  );
-
-  context.subscriptions.push(
-    vscode.workspace.onDidSaveTextDocument((e) => {
-      channel.appendLine(`[${timestamp()}] ${e.uri.fsPath} - saved`);
-    }),
-  );
-
-  context.subscriptions.push(
     vscode.workspace.onDidChangeTextDocument(async (e) => {
       if (!e.document.isDirty) {
         return;


### PR DESCRIPTION
### TL;DR

Removed unused file system event listeners from the VS Code extension.

### What changed?

Removed several event listeners that were logging file system events to the output channel:
- `onDidCloseTextDocument`
- `onDidCreateFiles`
- `onDidDeleteFiles`
- `onDidRenameFiles`
- `onDidSaveTextDocument`

The extension now only listens for text document changes (`onDidChangeTextDocument`).

### How to test?

1. Open the VS Code extension
2. Perform various file operations (create, save, delete, rename files)
3. Check the extension's output channel to verify that these operations are no longer being logged
4. Verify that text document changes are still being properly handled

### Why make this change?

These event listeners were likely adding unnecessary logging and overhead to the extension without providing value to users. Removing them simplifies the codebase and potentially improves performance by reducing the number of events the extension responds to.