### PR TITLE
refactor(backend): renamed metadata field to data

### DIFF
--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -79,7 +79,7 @@ export function activate(context: vscode.ExtensionContext) {
             {
               timestamp: timestamp(),
               eventType: workspaceEventName.parse("DID_CHANGE_TEXT_DOCUMENT"),
-              metadata: {
+              data: {
                 // contentChanges: e.contentChanges.map((change) => ({
                 //   // range: {
                 //   //   start: {

--- a/packages/backend/convex/api/extension.ts
+++ b/packages/backend/convex/api/extension.ts
@@ -12,7 +12,7 @@ export const addBatchedChangesMutation = mutation({
       v.object({
         eventType: v.string(),
         timestamp: v.number(),
-        metadata: v.record(v.string(), v.any()),
+        data: v.record(v.string(), v.any()),
       }),
     ),
   },
@@ -44,7 +44,7 @@ export const addBatchedChangesMutation = mutation({
         eventType: change.eventType,
         timestamp: change.timestamp,
         workspaceId: "ks74y4q2sn8x2t0t31nq5cb32s7vvjy5" as Id<"workspaces">, //workspace._id,
-        metadata: change.metadata,
+        data: change.data,
       };
       const eventId = await ctx.db.insert("events", newEvent);
       insertedIds.push(eventId);

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -19,8 +19,8 @@ export default defineSchema({
   events: defineTable({
     eventType: v.string(),
     timestamp: v.number(),
+    data: v.record(v.string(), v.any()),
     workspaceId: v.id("workspaces"),
-    metadata: v.record(v.string(), v.any()),
   }),
   flags: defineTable({
     description: v.string(),

--- a/packages/backend/convex/web/replay.ts
+++ b/packages/backend/convex/web/replay.ts
@@ -3,10 +3,8 @@ import { query } from "../_generated/server";
 import { authComponent } from "../auth";
 
 export const getReplays = query({
-  args: {
-  },
+  args: {},
   handler: async (ctx, args) => {
-
     // const auth = authComponent.getAuthUser(ctx);
     // if (!auth) {
     //   throw new Error("Unauthorized");
@@ -15,16 +13,22 @@ export const getReplays = query({
     const allEvents = await ctx.db.query("events").collect();
 
     // bucket events by workspaceId
-    const eventsByWorkspaceId = allEvents.reduce((acc, event) => {
-      acc[event.workspaceId] = [...(acc[event.workspaceId] || []), event.metadata];
-      return acc;
-    }, {} as Record<Id<"workspaces">, Record<string, any>[]> );
+    const eventsByWorkspaceId = allEvents.reduce(
+      (acc, event) => {
+        acc[event.workspaceId] = [
+          ...(acc[event.workspaceId] || []),
+          event.data,
+        ];
+        return acc;
+      },
+      {} as Record<Id<"workspaces">, Record<string, any>[]>,
+    );
 
     for (const workspaceId in eventsByWorkspaceId) {
-        const l = eventsByWorkspaceId[workspaceId as Id<"workspaces">]
-        if (!l) continue;
+      const l = eventsByWorkspaceId[workspaceId as Id<"workspaces">];
+      if (!l) continue;
 
-        l.sort((a, b) => a.timestamp - b.timestamp);
+      l.sort((a, b) => a.timestamp - b.timestamp);
     }
 
     return eventsByWorkspaceId;


### PR DESCRIPTION
### TL;DR

Renamed `metadata` field to `data` in workspace events schema and related code.

### What changed?

- Renamed the `metadata` field to `data` in the VSCode extension's event emission
- Updated the Convex schema to use `data` instead of `metadata` in the events table
- Modified the mutation API to accept `data` instead of `metadata`
- Updated the replay functionality to reference `event.data` instead of `event.metadata`

### How to test?

1. Run the VSCode extension and verify that events are still being properly recorded
2. Check the Convex database to confirm events are stored with the `data` field
3. Verify that the replay functionality works correctly with the renamed field

### Why make this change?

metadata is vague since it could include timestamp, workspace id, and event type. But really it should just describe the details of an event. so I'm renaming this to data.