### PR TITLE
refactor(extension): comment out low priority event listeners

### DIFF
--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -21,42 +21,48 @@ export function activate(context: vscode.ExtensionContext) {
     return Date.now();
   }
 
-  context.subscriptions.push(
-    vscode.workspace.onDidOpenTextDocument((e) => {
-      channel.appendLine(`[${timestamp()}] ${e.uri.fsPath} - opened`);
-    }),
-  );
+  // TODO: workspace ingestion flow implementation for this event is low priority but could potentially be useful
+  // context.subscriptions.push(
+  //   vscode.workspace.onDidOpenTextDocument((e) => {
+  //     channel.appendLine(`[${timestamp()}] ${e.uri.fsPath} - opened`);
+  //   }),
+  // );
 
-  context.subscriptions.push(
-    vscode.workspace.onDidCloseTextDocument((e) => {
-      channel.appendLine(`[${timestamp()}] ${e.uri.fsPath} - closed`);
-    }),
-  );
+  // TODO: workspace ingestion flow implementation for this event is low priority but could potentially be useful
+  // context.subscriptions.push(
+  //   vscode.workspace.onDidCloseTextDocument((e) => {
+  //     channel.appendLine(`[${timestamp()}] ${e.uri.fsPath} - closed`);
+  //   }),
+  // );
 
-  context.subscriptions.push(
-    vscode.workspace.onDidCreateFiles((e) => {
-      channel.appendLine(
-        `[${timestamp()}] ${e.files.map((file) => file.fsPath).join(", ")} - created`,
-      );
-    }),
-  );
+  // TODO: workspace ingestion flow implementation for this event is low priority but could potentially be useful
+  // context.subscriptions.push(
+  //   vscode.workspace.onDidCreateFiles((e) => {
+  //     channel.appendLine(
+  //       `[${timestamp()}] ${e.files.map((file) => file.fsPath).join(", ")} - created`,
+  //     );
+  //   }),
+  // );
 
-  context.subscriptions.push(
-    vscode.workspace.onDidDeleteFiles((e) => {
-      channel.appendLine(
-        `[${timestamp()}] ${e.files.map((file) => file.fsPath).join(", ")} - deleted`,
-      );
-    }),
-  );
+  // TODO: workspace ingestion flow implementation for this event is low priority but could potentially be useful
+  // context.subscriptions.push(
+  //   vscode.workspace.onDidDeleteFiles((e) => {
+  //     channel.appendLine(
+  //       `[${timestamp()}] ${e.files.map((file) => file.fsPath).join(", ")} - deleted`,
+  //     );
+  //   }),
+  // );
 
-  context.subscriptions.push(
-    vscode.workspace.onDidRenameFiles((e) => {
-      channel.appendLine(
-        `[${timestamp()}] ${e.files.map((file) => file.oldUri.fsPath).join(", ")} - ${e.files.map((file) => file.newUri.fsPath).join(", ")} - renamed`,
-      );
-    }),
-  );
+  // TODO: workspace ingestion flow implementation for this event is low priority but could potentially be useful
+  // context.subscriptions.push(
+  //   vscode.workspace.onDidRenameFiles((e) => {
+  //     channel.appendLine(
+  //       `[${timestamp()}] ${e.files.map((file) => file.oldUri.fsPath).join(", ")} - ${e.files.map((file) => file.newUri.fsPath).join(", ")} - renamed`,
+  //     );
+  //   }),
+  // );
 
+  // TODO: workspace ingestion flow implementation for this event is low priority but could potentially be useful
   // context.subscriptions.push(
   //   vscode.workspace.onDidSaveTextDocument((e) => {
   //     channel.appendLine(`[${timestamp()}] ${e.uri.fsPath} - saved`);
@@ -108,6 +114,7 @@ export function activate(context: vscode.ExtensionContext) {
     }),
   );
 
+  // TODO: workspace ingestion flow for this event: https://github.com/Beanie-Brick-Band/leopard/issues/60
   // context.subscriptions.push(
   //   vscode.workspace.onDidAcceptCopy((e) => {
   //     channel.appendLine(
@@ -116,37 +123,41 @@ export function activate(context: vscode.ExtensionContext) {
   //   }),
   // );
 
-  context.subscriptions.push(
-    vscode.window.onDidChangeTextEditorSelection((e) => {
-      channel.appendLine(
-        `[${timestamp()}] ${e.textEditor.document.uri.fsPath} - ${e.selections.map((selection) => `${selection.start.line}:${selection.start.character} - ${selection.end.line}:${selection.end.character}`).join(", ")} - selection changed`,
-      );
-    }),
-  );
+  // TODO: workspace ingestion flow implementation for this event is low priority but could potentially be useful
+  // context.subscriptions.push(
+  //   vscode.window.onDidChangeTextEditorSelection((e) => {
+  //     channel.appendLine(
+  //       `[${timestamp()}] ${e.textEditor.document.uri.fsPath} - ${e.selections.map((selection) => `${selection.start.line}:${selection.start.character} - ${selection.end.line}:${selection.end.character}`).join(", ")} - selection changed`,
+  //     );
+  //   }),
+  // );
 
-  context.subscriptions.push(
-    vscode.window.onDidChangeTerminalState((e) => {
-      channel.appendLine(
-        `[${timestamp()}] ${e.name} ${e.state.shell} - terminal state changed`,
-      );
-    }),
-  );
+  // TODO: workspace ingestion flow for this event: https://github.com/Beanie-Brick-Band/leopard/issues/62
+  // context.subscriptions.push(
+  //   vscode.window.onDidChangeTerminalState((e) => {
+  //     channel.appendLine(
+  //       `[${timestamp()}] ${e.name} ${e.state.shell} - terminal state changed`,
+  //     );
+  //   }),
+  // );
 
-  context.subscriptions.push(
-    vscode.window.onDidChangeTerminalShellIntegration((e) => {
-      channel.appendLine(
-        `[${timestamp()}] ${e.terminal.name} ${e.terminal.state.shell} - terminal shell integration changed`,
-      );
-    }),
-  );
+  // TODO: workspace ingestion flow implementation for this event is low priority but could potentially be useful
+  // context.subscriptions.push(
+  //   vscode.window.onDidChangeTerminalShellIntegration((e) => {
+  //     channel.appendLine(
+  //       `[${timestamp()}] ${e.terminal.name} ${e.terminal.state.shell} - terminal shell integration changed`,
+  //     );
+  //   }),
+  // );
 
-  context.subscriptions.push(
-    vscode.window.onDidEndTerminalShellExecution((e) => {
-      channel.appendLine(
-        `[${timestamp()}] ${e.terminal.name} ${e.exitCode} ${e.execution.commandLine.value} - command executed`,
-      );
-    }),
-  );
+  // TODO: workspace ingestion flow for this event: https://github.com/Beanie-Brick-Band/leopard/issues/62
+  // context.subscriptions.push(
+  //   vscode.window.onDidEndTerminalShellExecution((e) => {
+  //     channel.appendLine(
+  //       `[${timestamp()}] ${e.terminal.name} ${e.exitCode} ${e.execution.commandLine.value} - command executed`,
+  //     );
+  //   }),
+  // );
 }
 
 // This method is called when your extension is deactivated


### PR DESCRIPTION
### TL;DR

Commented out unused event listeners in the VS Code extension with TODOs for future implementation.

### What changed?

- Commented out multiple event listeners in `extension.ts` that were previously active, including:
    - `onDidOpenTextDocument`
    - `onDidCloseTextDocument`
    - `onDidCreateFiles`
    - `onDidDeleteFiles`
    - `onDidRenameFiles`
    - `onDidChangeTextEditorSelection`
    - `onDidChangeTerminalState`
    - `onDidChangeTerminalShellIntegration`
    - `onDidEndTerminalShellExecution`
- Added TODO comments to each commented section indicating priority and potential future implementation
- Added GitHub issue references for specific events
- Removed the `coder.integration.test.ts` file from the coder-sdk package

### How to test?

1. Launch the VS Code extension
2. Verify that the extension still functions correctly without the removed event listeners
3. Confirm that the output channel no longer logs the commented-out events

### Why make this change?

This change focuses development efforts on core functionality by removing event listeners that were generating logs but not currently being used for workspace ingestion. The TODO comments and GitHub issue references provide a clear roadmap for which events might be implemented in the future and their relative priority, making it easier to track what needs to be done without cluttering the codebase with unused functionality.