### PR TITLE
feat(backend): add database seeding functionality

### DIFF
--- a/packages/backend/.gitignore
+++ b/packages/backend/.gitignore
@@ -1,2 +1,1 @@
-
 .env.local

--- a/packages/backend/convex/web/index.ts
+++ b/packages/backend/convex/web/index.ts
@@ -1,5 +1,6 @@
 import { formatISO } from "date-fns";
 
+import { Id } from "../_generated/dataModel";
 import { internalMutation } from "../_generated/server";
 
 export const createMock = internalMutation(async (ctx) => {
@@ -38,4 +39,406 @@ export const createMock = internalMutation(async (ctx) => {
     metadata: "{}",
     ownerId: "user_456", // sample user that does not exist
   });
+
+  await Promise.all(
+    events.map((event) =>
+      ctx.db.insert("events", {
+        ...event,
+        workspaceId: event.workspaceId as Id<"workspaces">,
+      }),
+    ),
+  );
 });
+
+const events = [
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 8.0, line: 0.0 },
+            start: { column: 8.0, line: 0.0 },
+          },
+          text: ":",
+        },
+      ],
+    },
+    timestamp: 1769638584411.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 5.0, line: 0.0 },
+            start: { column: 5.0, line: 0.0 },
+          },
+          text: "()",
+        },
+      ],
+    },
+    timestamp: 1769638583322.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 6.0, line: 0.0 },
+            start: { column: 6.0, line: 0.0 },
+          },
+          text: "n",
+        },
+      ],
+    },
+    timestamp: 1769638584081.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 4.0, line: 0.0 },
+            start: { column: 4.0, line: 0.0 },
+          },
+          text: "f",
+        },
+      ],
+    },
+    timestamp: 1769638583101.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 2.0, line: 0.0 },
+            start: { column: 2.0, line: 0.0 },
+          },
+          text: "f",
+        },
+      ],
+    },
+    timestamp: 1769638578000.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 7.0, line: 1.0 },
+            start: { column: 7.0, line: 1.0 },
+          },
+          text: "s",
+        },
+      ],
+    },
+    timestamp: 1769638590601.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 5.0, line: 1.0 },
+            start: { column: 5.0, line: 1.0 },
+          },
+          text: "a",
+        },
+      ],
+    },
+    timestamp: 1769638590410.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 0.0, line: 0.0 },
+            start: { column: 0.0, line: 0.0 },
+          },
+          text: "def f(n):\n",
+        },
+      ],
+    },
+    timestamp: 1769638624564.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 4.0, line: 1.0 },
+            start: { column: 4.0, line: 1.0 },
+          },
+          text: "p",
+        },
+      ],
+    },
+    timestamp: 1769638590246.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 7.0, line: 0.0 },
+            start: { column: 7.0, line: 0.0 },
+          },
+          text: ")",
+        },
+      ],
+    },
+    timestamp: 1769638584241.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 1.0, line: 0.0 },
+            start: { column: 1.0, line: 0.0 },
+          },
+          text: "e",
+        },
+      ],
+    },
+    timestamp: 1769638577954.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 6.0, line: 1.0 },
+            start: { column: 6.0, line: 1.0 },
+          },
+          text: "s",
+        },
+      ],
+    },
+    timestamp: 1769638590477.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 3.0, line: 0.0 },
+            start: { column: 3.0, line: 0.0 },
+          },
+          text: " ",
+        },
+      ],
+    },
+    timestamp: 1769638578079.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 9.0, line: 0.0 },
+            start: { column: 9.0, line: 0.0 },
+          },
+          text: "\n    ",
+        },
+      ],
+    },
+    timestamp: 1769638588349.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 9.0, line: 0.0 },
+            start: { column: 9.0, line: 0.0 },
+          },
+          text: "\n    pass",
+        },
+      ],
+    },
+    timestamp: 1769638620218.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 7.0, line: 0.0 },
+            start: { column: 6.0, line: 0.0 },
+          },
+          text: ")",
+        },
+      ],
+    },
+    timestamp: 1769638583402.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 5.0, line: 1.0 },
+            start: { column: 4.0, line: 1.0 },
+          },
+          text: "",
+        },
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 5.0, line: 0.0 },
+            start: { column: 4.0, line: 0.0 },
+          },
+          text: "",
+        },
+      ],
+    },
+    timestamp: 1769638600190.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 8.0, line: 1.0 },
+            start: { column: 9.0, line: 0.0 },
+          },
+          text: "",
+        },
+      ],
+    },
+    timestamp: 1769638619035.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 0.0, line: 1.0 },
+            start: { column: 0.0, line: 0.0 },
+          },
+          text: "",
+        },
+      ],
+    },
+    timestamp: 1769638622957.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 4.0, line: 1.0 },
+            start: { column: 4.0, line: 1.0 },
+          },
+          text: "h",
+        },
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 4.0, line: 0.0 },
+            start: { column: 4.0, line: 0.0 },
+          },
+          text: "h",
+        },
+      ],
+    },
+    timestamp: 1769638598663.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 0.0, line: 0.0 },
+            start: { column: 0.0, line: 0.0 },
+          },
+          text: "d",
+        },
+      ],
+    },
+    timestamp: 1769638577793.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+  {
+    eventType: "DID_CHANGE_TEXT_DOCUMENT",
+    metadata: {
+      contentChanges: [
+        {
+          filePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+          range: {
+            end: { column: 7.0, line: 0.0 },
+            start: { column: 6.0, line: 0.0 },
+          },
+          text: "",
+        },
+      ],
+    },
+    timestamp: 1769638583829.0,
+    workspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+  },
+];


### PR DESCRIPTION
### TL;DR

Added event seeding. Final script should look like

```python
def f(n):
    pass
```

### What changed?

- modified `createMock` endpoint to mock additional events to the database

### How to test?

1. Run `index:createMock` on the convex dashboard
2. Verify that the sample events are properly loaded into the database
3. verify that localhost:3000/replay displays the replay

### Why make this change?

This change provides an easy way to seed event data. Resolves #85