### PR TITLE
feat: add play/pause button and auto-play to scrubber component

### DIFF
--- a/apps/nextjs/src/components/scrubber.tsx
+++ b/apps/nextjs/src/components/scrubber.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useQuery } from "convex/react";
 import { Scrubber } from "react-scrubber";
@@ -35,7 +35,7 @@ export const TextReplayScrubberComponent: React.FC = () => {
     end: m + 0.3,
   }));
 
-  const [state, setState] = React.useState<{
+  const [state, setState] = useState<{
     value: number;
     state: string;
     isScrubbing?: boolean;
@@ -47,10 +47,10 @@ export const TextReplayScrubberComponent: React.FC = () => {
     stickingTo: null,
   });
 
-  const [isPlaying, setIsPlaying] = React.useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
 
   // Auto-play effect
-  React.useEffect(() => {
+  useEffect(() => {
     if (!isPlaying) return;
 
     const interval = setInterval(() => {
@@ -254,7 +254,6 @@ export function insertText(
 }
 
 export function deleteText(lines: string[], range: Range): void {
-
   const isMultiLineDeletion = range.start.line !== range.end.line;
 
   if (!isMultiLineDeletion) {


### PR DESCRIPTION
### TL;DR

Added a play/pause button to the code replay scrubber and improved its functionality. Removed code for basic hard coded replay

### What changed?

- Added play/pause functionality with auto-play that advances the scrubber automatically
- Removed hardcoded test code and unnecessary assertions
- Changed default scrubber value from 50 to 0 to start at the beginning
- Updated UI to replace debug information with a play/pause button
- Fixed a comment description (changed "stick" to "marker")
- Simplified the code by removing the character-based scrubbing option

### How to test?

1. Open the code replay scrubber component
2. Click the play button to see the code replay automatically
3. Click pause to stop the playback
4. Try manually scrubbing to verify it still works and pauses auto-playback
5. Verify the scrubber starts at the beginning (0%) instead of the middle

### Why make this change?

This change improves the user experience by adding a more intuitive way to watch code replays. Instead of manually scrubbing through the timeline, users can now press play and watch the code being written automatically. Starting the scrubber at 0 instead of 50 provides a more natural viewing experience, and removing debug information cleans up the UI.