### PR TITLE
fix(coder-sdk): prevent coder.integration.test.ts from being deleted on build

### DIFF
--- a/packages/coder-sdk/tests/coder.integration.test.ts
+++ b/packages/coder-sdk/tests/coder.integration.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { createClient, createConfig } from "./client";
-import { buildInfo } from "./sdk.gen";
+import { buildInfo } from "@package/coder-sdk";
+import { createClient, createConfig } from "@package/coder-sdk/client";
 
 describe("Coder integration tests", () => {
   let client: ReturnType<typeof createClient>;

--- a/packages/coder-sdk/vitest.config.ts
+++ b/packages/coder-sdk/vitest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
-    include: ["src/**/*.test.{ts,tsx}", "src/**/*.integration.test.{ts,tsx}"],
+    include: [
+      "tests/**/*.test.{ts,tsx}",
+      "tests/**/*.integration.test.{ts,tsx}",
+    ],
   },
 });


### PR DESCRIPTION
## Summary

- Moves `coder.integration.test.ts` from `src/` to a new `tests/` directory outside the generated output path
- Updates `vitest.config.ts` to include test files from the new `tests/` directory

## Problem

The `@hey-api/openapi-ts` code generator cleans (deletes) the entire output directory (`src/`) before regenerating files. This was causing `coder.integration.test.ts` to be deleted every time `pnpm build` or `pnpm dev` was run.

## Solution

By moving the test file outside the `src/` directory (which is the code generation output path), it will no longer be affected by the clean operation during code generation.

Fixes #95