### PR TITLE
feat(vscode-extension): move convex url from env to vscode settings

### DIFF
--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -22,14 +22,15 @@ If you have any requirements or dependencies, add a section describing those and
 
 ## Extension Settings
 
-Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
-
-For example:
-
 This extension contributes the following settings:
 
-- `myExtension.enable`: Enable/disable this extension.
-- `myExtension.thing`: Set to `blah` to do something.
+- `leopard.convexUrl`: The URL of the Convex deployment to send events to. Defaults to `https://optimistic-kangaroo-331.convex.cloud`.
+
+To configure the Convex URL:
+
+1. Open VS Code settings (File > Preferences > Settings or `Cmd/Ctrl + ,`)
+2. Search for "Leopard"
+3. Update the "Convex URL" setting with your Convex deployment URL
 
 ## Known Issues
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -18,6 +18,18 @@
     "onStartupFinished"
   ],
   "main": "./dist/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "Leopard",
+      "properties": {
+        "leopard.convexUrl": {
+          "type": "string",
+          "default": "https://optimistic-kangaroo-331.convex.cloud",
+          "description": "The URL of the Convex deployment to send events to"
+        }
+      }
+    }
+  },
   "scripts": {
     "build": "pnpx @vscode/vsce package --no-dependencies",
     "vscode:prepublish": "pnpm run package",
@@ -37,7 +49,6 @@
     "@package/backend": "workspace:*",
     "@package/prettier-config": "workspace:*",
     "@package/validators": "workspace:*",
-    "@t3-oss/env-core": "^0.13.8",
     "convex": "^1.29.0",
     "zod": "catalog:"
   },

--- a/apps/vscode-extension/src/env.ts
+++ b/apps/vscode-extension/src/env.ts
@@ -1,7 +1,0 @@
-import { z } from "zod";
-
-const envSchema = z.object({
-  CONVEX_URL: z.string(),
-});
-
-export const env = envSchema.parse(process.env);

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -6,8 +6,6 @@ import * as vscode from "vscode";
 import { api } from "@package/backend/convex/_generated/api";
 import * as WorkspaceEvents from "@package/validators/workspaceEvents";
 
-import { env } from "./env";
-
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -15,7 +13,10 @@ export function activate(context: vscode.ExtensionContext) {
   // This line of code will only be executed once when your extension is activated
   console.log('Congratulations, your extension "leopard" is now active!');
   const channel = vscode.window.createOutputChannel("eventlogger");
-  const client = new ConvexHttpClient(env.CONVEX_URL);
+
+  const configuration = vscode.workspace.getConfiguration("leopard");
+  const convexUrl = configuration.get<string>("convexUrl") ?? "";
+  const client = new ConvexHttpClient(convexUrl);
 
   function timestamp() {
     return Date.now();

--- a/packages/coder-sdk/package.json
+++ b/packages/coder-sdk/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "default": "./src/index.ts",
-      "types": "./src/index.ts"
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
     },
     "./client": {
-      "default": "./src/client/index.ts",
-      "types": "./src/client/index.ts"
+      "types": "./src/client/index.ts",
+      "default": "./src/client/index.ts"
     }
   },
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,9 +209,6 @@ importers:
       '@package/validators':
         specifier: workspace:*
         version: link:../../packages/validators
-      '@t3-oss/env-core':
-        specifier: ^0.13.8
-        version: 0.13.8(arktype@2.1.20)(typescript@5.9.3)(valibot@1.0.0-beta.15(typescript@5.9.3))(zod@4.1.12)
       convex:
         specifier: ^1.29.0
         version: 1.29.0(react@19.2.0)


### PR DESCRIPTION
### TL;DR

Replace hardcoded Convex URL with a configurable setting in VS Code extension.

### What changed?

- Added a VS Code configuration setting `leopard.convexUrl` to allow users to specify their Convex deployment URL
- Set a default value of `https://optimistic-kangaroo-331.convex.cloud`
- Removed the `env.ts` file that previously handled environment variables
- Removed the `@t3-oss/env-core` dependency as it's no longer needed

### How to test?

1. Open VS Code settings (File > Preferences > Settings)
2. Search for "Leopard"
3. Verify that the "Convex URL" setting exists with the default value
4. Change the URL to a different Convex deployment if needed
5. Restart the extension and verify it connects to the specified Convex deployment

### Why make this change?

This change improves the extension's flexibility by allowing users to configure which Convex deployment they want to connect to without requiring environment variables. This makes it easier for users to switch between different environments and simplifies the setup process.