### PR TITLE
feat(backend): add workspace detection from hostname

### DIFF
--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -38,5 +38,5 @@ export default defineSchema({
   workspaces: defineTable({
     coderWorkspaceId: v.string(),
     userId: v.string(), // map this to betterAuth user id
-  }),
+  }).index("coderWorkspaceId", ["coderWorkspaceId"]),
 });


### PR DESCRIPTION
### TL;DR

Improved extension tracking by automatically identifying workspaces from hostname information.

### What changed?

- Added a `hostname` parameter to the `addBatchedChangesMutation` function
- Implemented logic to extract the Coder workspace ID from the hostname (format: `coder-<workspaceId>-<pod-id>`)
- Added database lookup to find the workspace by its Coder workspace ID
- Replaced the hardcoded workspace ID with the actual workspace ID from the database lookup

### How to test?

1. Deploy the changes to a test environment
2. Trigger the extension to send events with the hostname parameter
3. Verify that events are correctly associated with the appropriate workspace
4. Check logs to ensure proper extraction of workspace IDs from hostnames

### Why make this change?

Previously, the extension was using a hardcoded workspace ID for all events, making it impossible to track which workspace was generating which events. This change enables proper tracking by automatically identifying the workspace from the hostname, allowing for accurate attribution of events to their respective workspaces.