### PR TITLE
feat: add extention release github action

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -1,0 +1,70 @@
+name: VS Code Extension
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "apps/vscode-extension/**"
+      - "packages/backend/**"
+      - "packages/validators/**"
+      - "pnpm-lock.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_COLOR: 3
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup
+        uses: ./tooling/github/setup
+
+      - name: Build VS Code Extension
+        run: pnpm --filter vscode-extension run build
+
+      - name: Get extension version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./apps/vscode-extension/package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extension version: $VERSION"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-extension-${{ steps.version.outputs.version }}
+          path: apps/vscode-extension/*.vsix
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: vscode-extension-v${{ steps.version.outputs.version }}-${{ github.run_number }}
+          name: VS Code Extension v${{ steps.version.outputs.version }} (Build ${{ github.run_number }})
+          files: apps/vscode-extension/*.vsix
+          generate_release_notes: true
+
+      - name: Update latest release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: vscode-extension-latest
+          name: VS Code Extension (Latest)
+          files: apps/vscode-extension/*.vsix
+          body: |
+            Latest VS Code extension build.
+
+            **Version:** ${{ steps.version.outputs.version }}
+            **Build:** ${{ github.run_number }}
+            **Commit:** ${{ github.sha }}
+
+            This release is automatically updated with each build on main.
+          make_latest: false


### PR DESCRIPTION
### TL;DR

Added a GitHub workflow to automatically build and release the VS Code extension.

### What changed?

Created a new GitHub Actions workflow file (`.github/workflows/vscode-extension.yml`) that:

- Triggers on pushes to the main branch when changes are made to the VS Code extension, backend, validators, or the lock file
- Builds the VS Code extension
- Extracts the version from the extension's package.json
- Uploads the built .vsix file as an artifact
- Creates two GitHub releases:
    1. A versioned release with the extension version and build number
    2. An always-updated "latest" release that points to the most recent build

### How to test?

1. Make a change to the VS Code extension code and push to main
2. Verify the workflow runs successfully
3. Check that a new GitHub release is created with the correct version
4. Confirm the "vscode-extension-latest" release is updated with the new build

### Why make this change?

This automation streamlines the release process for the VS Code extension, ensuring that users always have access to the latest version. It also maintains a history of versioned releases for reference and rollback purposes if needed.



Fixes #105