### PR TITLE
feat: allow manual trigger

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -1,6 +1,7 @@
 name: VS Code Extension
 
 on:
+  workflow_dispatch:
   push:
     branches: ["main"]
     paths:


### PR DESCRIPTION
### TL;DR

Added workflow_dispatch trigger to the VS Code Extension GitHub workflow.

### What changed?

Added the `workflow_dispatch` trigger to the VS Code Extension GitHub workflow configuration file. This allows the workflow to be manually triggered from the GitHub Actions UI.

### How to test?

1. Navigate to the Actions tab in the GitHub repository
2. Select the "VS Code Extension" workflow
3. Click on "Run workflow" dropdown
4. Verify that you can manually trigger the workflow

### Why make this change?

This change enables manual triggering of the VS Code Extension workflow, which is useful for testing or deploying the extension without having to push changes to the main branch or modify files in the specified paths.