### PR TITLE
refactor(extension-testing): simplify esbuild configuration

### DIFF
--- a/apps/vscode-extension/esbuild.mjs
+++ b/apps/vscode-extension/esbuild.mjs
@@ -1,11 +1,4 @@
-#!/usr/bin/env node
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
 import * as esbuild from "esbuild";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const production = process.argv.includes("--production");
 const watch = process.argv.includes("--watch");
@@ -34,16 +27,11 @@ const esbuildProblemMatcherPlugin = {
   },
 };
 
-// Create dist directory if it doesn't exist
-if (!fs.existsSync(path.join(__dirname, "dist"))) {
-  fs.mkdirSync(path.join(__dirname, "dist"), { recursive: true });
-}
-
 async function main() {
   const ctx = await esbuild.context({
     entryPoints: ["src/extension.ts"],
     bundle: true,
-    format: "esm", // ESM format for Node.js (package.json has "type": "module")
+    format: "esm",
     minify: production,
     sourcemap: !production,
     sourcesContent: false,
@@ -51,7 +39,6 @@ async function main() {
     outfile: "dist/extension.js",
     external: ["vscode"],
     logLevel: "silent",
-    target: ["node22"],
     plugins: [
       /* add to the end of plugins array */
       esbuildProblemMatcherPlugin,


### PR DESCRIPTION
### TL;DR

Simplified the esbuild configuration for the VS Code extension.

### What changed?

- Removed unnecessary imports (fs, path, url)
- Removed directory creation logic since it's handled automatically by esbuild
- Simplified error reporting in the problem matcher plugin
- Removed redundant comments
- Removed the explicit Node.js target version

### How to test?

1. Run the build process with `npm run build` or `npm run watch`
2. Verify that the extension builds correctly
3. Test the extension in VS Code to ensure it functions as expected

### Why make this change?

This change streamlines the build configuration by removing unnecessary code and dependencies. The simplified configuration is more maintainable while still providing the same functionality. The automatic directory creation by esbuild eliminates the need for manual filesystem operations.