### PR TITLE
test(extension): remove env file configuration from launch.json

### DIFF
--- a/apps/vscode-extension/.vscode/launch.json
+++ b/apps/vscode-extension/.vscode/launch.json
@@ -11,8 +11,7 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-      "preLaunchTask": "${defaultBuildTask}",
-      "envFile": "${workspaceFolder}/.env"
-    },
+      "preLaunchTask": "${defaultBuildTask}"
+    }
   ]
 }


### PR DESCRIPTION
### TL;DR

Removed the `.env` file configuration from the VS Code extension launch settings.

### What changed?

Removed the `envFile` property from the launch configuration in `apps/vscode-extension/.vscode/launch.json`. This property was previously pointing to `${workspaceFolder}/.env`.

### How to test?

1. Open the VS Code extension project
2. Launch the extension in debug mode
3. Verify that the extension launches correctly without loading environment variables from a `.env` file

### Why make this change?

The extension likely no longer requires environment variables to be loaded from a `.env` file during development, simplifying the setup process and reducing dependencies. This change streamlines the launch configuration by removing unnecessary configuration.