### PR TITLE
test(extension): configure tests to work with ESM modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 
 # testing
 coverage
+.vscode-test/
 
 # next.js
 .next/
@@ -57,3 +58,5 @@ infra/.terraform
 infra/*.tfvars
 infra/*.tfstate
 infra/*.tfstate.*
+
+*.vsix

--- a/apps/vscode-extension/.vscode-test.mjs
+++ b/apps/vscode-extension/.vscode-test.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from '@vscode/test-cli';
+import { defineConfig } from "@vscode/test-cli";
 
 export default defineConfig({
-	files: 'out/test/**/*.test.js',
+  files: "out/test/**/*.test.cjs",
 });

--- a/apps/vscode-extension/esbuild.test.mjs
+++ b/apps/vscode-extension/esbuild.test.mjs
@@ -1,0 +1,60 @@
+import * as fs from "fs";
+import * as esbuild from "esbuild";
+
+const watch = process.argv.includes("--watch");
+
+/**
+ * @type {import('esbuild').Plugin}
+ */
+const esbuildProblemMatcherPlugin = {
+  name: "esbuild-problem-matcher",
+
+  setup(build) {
+    build.onStart(() => {
+      console.log("[watch] build started");
+    });
+    build.onEnd((result) => {
+      result.errors.forEach(({ text, location }) => {
+        console.error(`✘ [ERROR] ${text}`);
+        if (location) {
+          console.error(
+            `    ${location.file}:${location.line}:${location.column}:`,
+          );
+        }
+      });
+      console.log("[watch] build finished");
+    });
+  },
+};
+
+async function main() {
+  // Ensure output directory exists
+  if (!fs.existsSync("out/test")) {
+    fs.mkdirSync("out/test", { recursive: true });
+  }
+
+  const ctx = await esbuild.context({
+    entryPoints: ["src/test/extension.test.ts"],
+    bundle: true,
+    format: "cjs",
+    platform: "node",
+    outfile: "out/test/extension.test.cjs",
+    external: ["vscode", "mocha"],
+    logLevel: watch ? "silent" : "info",
+    sourcemap: true,
+    target: "node18",
+    plugins: [esbuildProblemMatcherPlugin],
+  });
+
+  if (watch) {
+    ctx.watch();
+  } else {
+    await ctx.rebuild();
+    await ctx.dispose();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "vscode-extension",
   "displayName": "leopard",
   "description": "Verify the legitamacy of student assignments by analyzing a granular version history of their work process. VSCode extension for the Leopard IDE.",
@@ -7,7 +8,6 @@
     "url": "https://github.com/Beanie-Brick-Band/leopard.git"
   },
   "version": "0.0.1",
-  "type": "module",
   "engines": {
     "vscode": "^1.105.0"
   },
@@ -38,8 +38,8 @@
     "watch:esbuild": "node esbuild.mjs --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
     "package": "pnpm run check-types && pnpm run lint && node esbuild.mjs --production",
-    "compile-tests": "tsc -p . --outDir out",
-    "watch-tests": "tsc -p . -w --outDir out",
+    "compile-tests": "node esbuild.test.mjs",
+    "watch-tests": "node esbuild.test.mjs --watch",
     "pretest": "pnpm run compile-tests && pnpm run compile && pnpm run lint",
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
@@ -60,6 +60,7 @@
     "@types/vscode": "^1.105.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
+    "convex-test": "^0.0.41",
     "esbuild": "^0.27.0",
     "eslint": "catalog:",
     "npm-run-all": "^4.1.5",

--- a/apps/vscode-extension/src/test/extension.test.ts
+++ b/apps/vscode-extension/src/test/extension.test.ts
@@ -1,15 +1,49 @@
-import * as assert from 'assert';
+import * as assert from "assert";
+import type { TestConvex } from "convex-test";
+import type { ConvexHttpClient } from "convex/browser";
+import { convexTest } from "convex-test";
+import * as vscode from "vscode";
 
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
-import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
+import { internal } from "@package/backend/convex/_generated/api";
+import * as apiModule from "@package/backend/convex/_generated/api";
+import * as apiExtensionModule from "@package/backend/convex/api/extension";
+import schema from "@package/backend/convex/schema";
+import * as webIndexModule from "@package/backend/convex/web/index";
+import * as webReplayModule from "@package/backend/convex/web/replay";
 
-suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+import { activate, deactivate } from "../extension";
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
+suite("Extension Test Suite", () => {
+  vscode.window.showInformationMessage("Start all tests.");
+
+  let mockClient: TestConvex<typeof schema> | null = null;
+
+  setup(async () => {
+    // Provide modules in the format expected by convex-test
+    // The modules object maps file paths to async functions that return the module exports
+    const modules: Record<string, () => Promise<unknown>> = {
+      "convex/_generated/api.ts": () => Promise.resolve(apiModule),
+      "convex/web/index.ts": () => Promise.resolve(webIndexModule),
+      "convex/web/replay.ts": () => Promise.resolve(webReplayModule),
+      "convex/api/extension.ts": () => Promise.resolve(apiExtensionModule),
+    };
+    mockClient = convexTest(schema, modules);
+
+    await mockClient.mutation(internal.web.index.createMock, {});
+
+    // Activate the extension (this will trigger the initialization code)
+    const mockContext = {
+      subscriptions: [] as { dispose: () => void }[],
+    } as vscode.ExtensionContext;
+    activate(mockContext, mockClient as unknown as ConvexHttpClient);
+  });
+
+  teardown(async () => {
+    await deactivate();
+  });
+
+  test("Sample test", () => {
+    assert.strictEqual(-1, [1, 2, 3].indexOf(5));
+    assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+  });
 });

--- a/apps/vscode-extension/tsconfig.json
+++ b/apps/vscode-extension/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "noEmit": true,
+    "noEmit": false,
     "lib": ["ES2022", "DOM"],
     "target": "ES2022",
     "sourceMap": true,
@@ -13,13 +13,7 @@
   },
   "include": ["src/**/*"],
 
-  "exclude": [
-    "node_modules"
-    // "../../packages/backend/convex/api",
-    // "../../packages/backend/convex/auth.ts",
-    // "../../packages/backend/convex/http.ts",
-    // "../../packages/backend/src"
-  ],
+  "exclude": ["node_modules", ".vscode-test"],
   "ts-node": {
     "esm": true
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@vscode/test-electron':
         specifier: ^2.5.2
         version: 2.5.2
+      convex-test:
+        specifier: ^0.0.41
+        version: 0.0.41(convex@1.29.0(react@19.2.0))
       esbuild:
         specifier: ^0.27.0
         version: 0.27.0
@@ -3879,6 +3882,11 @@ packages:
       zod:
         optional: true
 
+  convex-test@0.0.41:
+    resolution: {integrity: sha512-GPHeYFOi70n7UtW0eCEQFVhzl/+m8PvbWkDCbKpHLybI1MrScf4sVpGeM0cC2qmtxiduxa2nLPbehPalhh9oyQ==}
+    peerDependencies:
+      convex: ^1.16.4
+
   convex@1.29.0:
     resolution: {integrity: sha512-uoIPXRKIp2eLCkkR9WJ2vc9NtgQtx8Pml59WPUahwbrd5EuW2WLI/cf2E7XrUzOSifdQC3kJZepisk4wJNTJaA==}
     engines: {node: '>=18.0.0', npm: '>=7.0.0'}
@@ -4555,8 +4563,8 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.13.1:
-    resolution: {integrity: sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==}
+  get-tsconfig@4.13.3:
+    resolution: {integrity: sha512-vp8Cj/+9Q/ibZUrq1rhy8mCTQpCk31A3uu9wc1C50yAb3x2pFHOsGdAZQ7jD86ARayyxZUViYeIztW+GE8dcrg==}
 
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
@@ -10226,6 +10234,10 @@ snapshots:
       typescript: 5.9.3
       zod: 4.1.12
 
+  convex-test@0.0.41(convex@1.29.0(react@19.2.0)):
+    dependencies:
+      convex: 1.29.0(react@19.2.0)
+
   convex@1.29.0(react@19.2.0):
     dependencies:
       esbuild: 0.25.4
@@ -11127,7 +11139,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
-  get-tsconfig@4.13.1:
+  get-tsconfig@4.13.3:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -13819,7 +13831,7 @@ snapshots:
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.0
-      get-tsconfig: 4.13.1
+      get-tsconfig: 4.13.3
     optionalDependencies:
       fsevents: 2.3.3
 


### PR DESCRIPTION
### TL;DR

Set up VSCode extension testing infrastructure with convex-test integration.

### What changed?

- Added esbuild configuration for tests with a new `esbuild.test.mjs` file
- Updated the extension to accept an optional client parameter for testing
- Modified the test setup to use `convex-test` for mocking the Convex backend
- Changed test file format from `.js` to `.cjs` in the VSCode test configuration
- Made `deactivate()` function async to properly await flush operations
- Updated `.gitignore` to exclude `.vscode-test/` directory and `.vsix` files

### How to test?

1. Run `pnpm compile-tests` to build the test files
2. Run `pnpm test` to execute the tests with the VSCode test runner
3. For development, use `pnpm watch-tests` to automatically rebuild tests on changes

### Why make this change?

This change enables proper testing of the VSCode extension with mocked Convex backend interactions. By using `convex-test`, we can simulate API calls without requiring a real Convex deployment, making tests more reliable and faster. The esbuild configuration for tests ensures consistent bundling between the extension and its tests.