### PR TITLE
test(extension): add watch mode to test build process

### DIFF
--- a/apps/vscode-extension/esbuild.test.mjs
+++ b/apps/vscode-extension/esbuild.test.mjs
@@ -1,31 +1,139 @@
+import * as fs from "fs";
 import * as esbuild from "esbuild";
 
+const watch = process.argv.includes("--watch");
+
+// Build counter to track related ESM/CJS builds
+let buildCounter = 0;
+
+// ANSI color codes - 3 colors that alternate between ESM and CJS
+const colors = {
+  reset: "\x1b[0m",
+  // 3 colors: yellow, blue, red
+  palette: ["\x1b[33m", "\x1b[36m", "\x1b[31m"], // yellow, cyan, red
+};
+
+// Single color index that alternates for all builds
+let colorIndex = 0;
+
+/**
+ * Creates a problem matcher plugin with a build name and unique ID for identification
+ * @param {string} buildName - Name to identify this build (e.g., "ESM" or "CJS")
+ * @param {() => number} getIdFn - Function that returns the current build ID
+ * @returns {import('esbuild').Plugin}
+ */
+function createProblemMatcherPlugin(buildName, getIdFn) {
+  return {
+    name: `esbuild-problem-matcher-${buildName.toLowerCase()}`,
+
+    setup(build) {
+      let buildId = null;
+      let buildColor = null;
+
+      build.onStart(() => {
+        buildId = getIdFn();
+        buildColor = colors.palette[colorIndex % 3];
+        colorIndex++;
+        console.log(
+          `${buildColor}  [${buildName}#${buildId}] build started${colors.reset}`,
+        );
+      });
+
+      build.onEnd((result) => {
+        // Use the ID and color captured at start
+        const id = buildId ?? getIdFn();
+        const color = buildColor ?? colors.palette[(colorIndex - 1) % 3];
+        if (result.errors.length > 0) {
+          console.error(
+            `${color}✘ [${buildName}#${id}] build failed with ${result.errors.length} error(s)${colors.reset}`,
+          );
+          result.errors.forEach(({ text, location }) => {
+            console.error(
+              `${color}✘ [${buildName}#${id}] ${text}${colors.reset}`,
+            );
+            if (location) {
+              console.error(
+                `${color}    ${location.file}:${location.line}:${location.column}:`,
+              );
+            }
+          });
+        } else {
+          console.log(
+            `${color}✔ [${buildName}#${id}] build finished successfully${colors.reset}`,
+          );
+        }
+      });
+    },
+  };
+}
+
 async function main() {
+  // Ensure output directory exists
+  if (!fs.existsSync("out/test")) {
+    fs.mkdirSync("out/test", { recursive: true });
+  }
+
+  // Track build IDs - each build (ESM and CJS) gets its own incrementing ID
+  const getEsmBuildId = () => {
+    // Increment and return new ID when ESM starts
+    return ++buildCounter;
+  };
+  const getCjsBuildId = () => {
+    // Increment and return new ID when CJS starts
+    return ++buildCounter;
+  };
+
   // First, bundle as ES module (.mjs) to support convex-test which requires ESM
-  await esbuild.build({
+  const esmCtx = await esbuild.context({
     entryPoints: ["src/test/extension.test.ts"],
     bundle: true,
     format: "esm",
     platform: "node",
     outfile: "out/test/extension.test.mjs",
     external: ["vscode", "mocha"],
-    logLevel: "info",
+    logLevel: watch ? "silent" : "info",
     sourcemap: true,
     target: "node18",
+    plugins: [createProblemMatcherPlugin("ESM", getEsmBuildId)],
   });
 
   // Then, convert the ESM bundle to CommonJS (.cjs) for the test runner
-  await esbuild.build({
+  const cjsCtx = await esbuild.context({
     entryPoints: ["out/test/extension.test.mjs"],
-    bundle: true, // Re-bundle to convert format
+    bundle: true,
     format: "cjs",
     platform: "node",
     outfile: "out/test/extension.test.cjs",
     external: ["vscode", "mocha"],
-    logLevel: "info",
+    logLevel: watch ? "silent" : "info",
     sourcemap: true,
     target: "node18",
+    plugins: [createProblemMatcherPlugin("CJS", getCjsBuildId)],
   });
+
+  if (watch) {
+    // Do initial builds
+    await esmCtx.rebuild();
+    await cjsCtx.rebuild();
+
+    // Start watching both - CJS will automatically rebuild when ESM file changes
+    // Don't await these - they run indefinitely
+    esmCtx.watch();
+    cjsCtx.watch();
+
+    // Keep process alive - prevent exit
+    process.stdin.resume();
+    process.on("SIGINT", async () => {
+      await esmCtx.dispose();
+      await cjsCtx.dispose();
+      process.exit(0);
+    });
+  } else {
+    await esmCtx.rebuild();
+    await cjsCtx.rebuild();
+    await esmCtx.dispose();
+    await cjsCtx.dispose();
+  }
 }
 
 main().catch((e) => {

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -39,7 +39,7 @@
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
     "package": "pnpm run check-types && pnpm run lint && node esbuild.mjs --production",
     "compile-tests": "node esbuild.test.mjs",
-    "watch-tests": "tsc -p . -w --outDir out",
+    "watch-tests": "node esbuild.test.mjs --watch",
     "pretest": "pnpm run compile-tests && pnpm run compile && pnpm run lint",
     "check-types": "tsc --noEmit",
     "lint": "eslint src",


### PR DESCRIPTION
# Improved Test Build System for VS Code Extension

### TL;DR

Enhanced the test build system with watch mode support and better build output formatting.

### What changed?

- Added watch mode support to the test build process
- Implemented colored console output with build IDs to distinguish between ESM and CJS builds
- Created a problem matcher plugin to format build errors and successes
- Switched from direct builds to esbuild contexts for better control
- Updated the `watch-tests` script in package.json to use the enhanced build system

### How to test?

1. Run `pnpm run watch-tests` to start the test build in watch mode
2. Make changes to test files and observe the colored output showing both ESM and CJS builds
3. Press Ctrl+C to stop the watch process
4. Run `pnpm run compile-tests` to verify the standard build still works

### Why make this change?

The previous test build system lacked proper watch mode support and clear build output, making it difficult to track build progress and errors during development. This enhancement improves developer experience by providing real-time feedback with colored output and automatic rebuilds when files change.