### PR TITLE
test(extension): add hostname mocking for testing

### DIFF
--- a/apps/vscode-extension/src/test/extension.test.ts
+++ b/apps/vscode-extension/src/test/extension.test.ts
@@ -35,7 +35,11 @@ suite("Extension Test Suite", () => {
     const mockContext = {
       subscriptions: [] as { dispose: () => void }[],
     } as vscode.ExtensionContext;
-    activate(mockContext, mockClient as unknown as ConvexHttpClient);
+    activate(
+      mockContext,
+      mockClient as unknown as ConvexHttpClient,
+      "coder-273044a0-03a7-49ef-b1a4-e1bbc3c49d9b-7b78cdf4d9-mx66l",
+    );
   });
 
   teardown(async () => {

--- a/packages/backend/convex/web/index.ts
+++ b/packages/backend/convex/web/index.ts
@@ -47,8 +47,10 @@ export const createMock = internalMutation(async (ctx) => {
     releaseDate: 1704067200000, // December 31, 2023 - in the past
   });
 
+  // Use some placeholder workspace ID that matches the requirements specified in
+  // addBatchedChangesMutation
   const workspaceId = await ctx.db.insert("workspaces", {
-    coderWorkspaceId: "jx75g1jdes38h6v3bq54w7z2zn7z51kf",
+    coderWorkspaceId: "273044a0-03a7-49ef-b1a4-e1bbc3c49d9b",
     isActive: true,
     userId: "user_123", // sample user that does not exist
   });


### PR DESCRIPTION
### TL;DR

Added hostname parameter to the VSCode extension to improve tracking and debugging capabilities.

### What changed?

- Modified the `activate` function to accept an optional `hostname` parameter
- Updated the `BatchedConvexHttpClient` constructor to take a hostname parameter instead of directly using `os.hostname()`
- Stored the hostname as a class property in `BatchedConvexHttpClient`
- Used the stored hostname when submitting events instead of calling `os.hostname()` each time
- Updated test to pass a specific hostname value
- Updated the mock workspace ID in `createMock` function to match the format used in tests

### How to test?

1. Run the VSCode extension
2. Verify that the hostname is correctly logged in the output channel
3. Trigger some events and confirm they are submitted with the correct hostname
4. Run `pnpm test` to execute the tests with the VSCode test runner

### Why make this change?

This change improves the flexibility of the extension by allowing the hostname to be specified externally rather than always using the system's hostname. This is particularly useful for testing environments and containerized deployments where the system hostname might not be meaningful or consistent. It also reduces redundant calls to `os.hostname()` by storing the value once during initialization.