### PR TITLE
test(extension): add onDidChangeTextDocument testing

### DIFF
--- a/apps/vscode-extension/.vscode-test.mjs
+++ b/apps/vscode-extension/.vscode-test.mjs
@@ -2,4 +2,5 @@ import { defineConfig } from "@vscode/test-cli";
 
 export default defineConfig({
   files: "out/test/**/*.test.cjs",
+  launchArgs: ["./src/test"],
 });

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -168,7 +168,7 @@ export async function deactivate() {
   await BatchedConvexHttpClient.flushAndResetInstance();
 }
 
-class BatchedConvexHttpClient {
+export class BatchedConvexHttpClient {
   private static instance: BatchedConvexHttpClient | null = null;
   private client: ConvexHttpClient;
   private debouncer: NodeJS.Timeout | null = null;

--- a/apps/vscode-extension/src/test/extension.test.ts
+++ b/apps/vscode-extension/src/test/extension.test.ts
@@ -4,19 +4,23 @@ import type { ConvexHttpClient } from "convex/browser";
 import { convexTest } from "convex-test";
 import * as vscode from "vscode";
 
-import { internal } from "@package/backend/convex/_generated/api";
+import type { Id } from "@package/backend/convex/_generated/dataModel";
+import { api, internal } from "@package/backend/convex/_generated/api";
 import * as apiModule from "@package/backend/convex/_generated/api";
 import * as apiExtensionModule from "@package/backend/convex/api/extension";
 import schema from "@package/backend/convex/schema";
 import * as webIndexModule from "@package/backend/convex/web/index";
 import * as webReplayModule from "@package/backend/convex/web/replay";
+import * as WorkspaceEvents from "@package/validators/workspaceEvents";
 
-import { activate, deactivate } from "../extension";
+import { activate, BatchedConvexHttpClient, deactivate } from "../extension";
 
 suite("Extension Test Suite", () => {
   vscode.window.showInformationMessage("Start all tests.");
 
-  let mockClient: TestConvex<typeof schema> | null = null;
+  let mockClient: TestConvex<typeof schema>;
+  let workspaceId: Id<"workspaces">;
+  let workspaceUri: vscode.Uri;
 
   setup(async () => {
     // Provide modules in the format expected by convex-test
@@ -31,23 +35,86 @@ suite("Extension Test Suite", () => {
 
     await mockClient.mutation(internal.web.index.createMock, {});
 
-    // Activate the extension (this will trigger the initialization code)
+    const coderWorkspaceId = "273044a0-03a7-49ef-b1a4-e1bbc3c49d9b";
+    const unverifiedWorkspaceId = await mockClient.query(
+      internal.web.index.getWorkspaceByCoderWorkspaceId,
+      { coderWorkspaceId },
+    );
+    assert.ok(unverifiedWorkspaceId, "Workspace should exist");
+    workspaceId = unverifiedWorkspaceId;
+
+    const newWorkspaceUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+    assert.ok(newWorkspaceUri, "Workspace folder should exist");
+    workspaceUri = newWorkspaceUri;
+
+    const wsEdit = new vscode.WorkspaceEdit();
+    wsEdit.createFile(vscode.Uri.joinPath(workspaceUri, "test-dummy.ts"), {
+      ignoreIfExists: true,
+    });
+    const success = await vscode.workspace.applyEdit(wsEdit);
+    assert.ok(success, "test-dummy.ts file should be created");
+
     const mockContext = {
       subscriptions: [] as { dispose: () => void }[],
     } as vscode.ExtensionContext;
     activate(
       mockContext,
       mockClient as unknown as ConvexHttpClient,
-      "coder-273044a0-03a7-49ef-b1a4-e1bbc3c49d9b-7b78cdf4d9-mx66l",
+      `coder-${coderWorkspaceId}-7b78cdf4d9-mx66l`,
     );
   });
 
   teardown(async () => {
     await deactivate();
+
+    const wsEdit = new vscode.WorkspaceEdit();
+    wsEdit.deleteFile(vscode.Uri.joinPath(workspaceUri, "test-dummy.ts"));
+    const success = await vscode.workspace.applyEdit(wsEdit);
+    assert.ok(success, "test-dummy.ts file should be deleted");
   });
 
-  test("Sample test", () => {
-    assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-    assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+  test("onDidChangeTextDocument event is sent to Convex", async () => {
+    const wsEdit = new vscode.WorkspaceEdit();
+    const fileUri = vscode.Uri.joinPath(workspaceUri, "test-dummy.ts");
+    wsEdit.insert(fileUri, new vscode.Position(0, 0), "Hello, world!");
+    const success = await vscode.workspace.applyEdit(wsEdit);
+    assert.ok(success, "Hello, world! should be inserted into test-dummy.ts");
+
+    // events are not immediately sent to the mockClient because of the debounce delay, so
+    // we need this to bypass the debounce and flush the buffer
+    await BatchedConvexHttpClient.getInstance().flush();
+
+    const replay = await mockClient.query(api.web.replay.getReplay, {
+      workspaceId,
+    });
+    const lastEvent = replay[replay.length - 1];
+    assert.ok(replay.length > 0, "Replay should contain at least one event");
+    assert.deepStrictEqual(
+      lastEvent,
+      {
+        eventType: WorkspaceEvents.NAME.DID_CHANGE_TEXT_DOCUMENT,
+        timestamp: lastEvent?.timestamp, // the timestamp value can vary too much for testing
+        workspaceId: lastEvent?.workspaceId, // workspaceId is included in the parsed event
+        metadata: {
+          contentChanges: [
+            {
+              range: {
+                start: {
+                  line: 0,
+                  column: 0,
+                },
+                end: {
+                  line: 0,
+                  column: 0,
+                },
+              },
+              text: "Hello, world!",
+              filePath: fileUri.fsPath,
+            },
+          ],
+        },
+      },
+      "Event object should match expected structure",
+    );
   });
 });

--- a/packages/backend/convex/web/index.ts
+++ b/packages/backend/convex/web/index.ts
@@ -1,4 +1,6 @@
-import { internalMutation } from "../_generated/server";
+import { v } from "convex/values";
+
+import { internalMutation, internalQuery } from "../_generated/server";
 
 export const createMock = internalMutation(async (ctx) => {
   if (
@@ -25,14 +27,13 @@ export const createMock = internalMutation(async (ctx) => {
     assistantIds: [],
   });
 
-
   const assignment1Id = await ctx.db.insert("assignments", {
     dueDate: 1911614400000, // July 30, 2030 - sometime in the future
     name: "Sample Homework",
     releaseDate: 1704067200000, // December 31, 2023 - in the past
     classroomId: classroom1Id,
   });
-  
+
   const assignment2Id = await ctx.db.insert("assignments", {
     dueDate: 1912996800000, // August 15, 2030 - sometime in the future
     name: "Sample Project",
@@ -71,6 +72,20 @@ export const createMock = internalMutation(async (ctx) => {
       }),
     ),
   );
+});
+
+export const getWorkspaceByCoderWorkspaceId = internalQuery({
+  args: { coderWorkspaceId: v.string() },
+  handler: async (ctx, args) => {
+    const workspace = await ctx.db
+      .query("workspaces")
+      .withIndex("coderWorkspaceId", (q) =>
+        q.eq("coderWorkspaceId", args.coderWorkspaceId),
+      )
+      .first();
+
+    return workspace?._id ?? null;
+  },
 });
 
 const events = [


### PR DESCRIPTION
### TL;DR

Added VS Code extension tests for workspace event tracking

### What changed?

- Enhanced the VS Code extension test configuration to use a specific test workspace
- Added a comprehensive test for the `onDidChangeTextDocument` event to verify that text changes are properly captured and sent to Convex
- Implemented proper test setup and teardown procedures to ensure clean test runs
- Added a new `getWorkspaceByCoderWorkspaceId` internal query to retrieve workspace IDs

### How to test?

1. Run the VS Code extension tests using the test command
2. Verify that the test creates a dummy file, modifies it, and correctly captures the text change event
3. Confirm that the event data structure matches the expected format with proper metadata

### Why make this change?

This change improves test coverage for the VS Code extension, specifically validating that workspace events are properly tracked and sent to Convex. The tests ensure that when users make changes to files in their workspace, these events are correctly captured with the appropriate metadata, which is essential for the extension's core functionality.  
  
resolves #220