### PR TITLE
fix: change autostop to 1 hr

### DIFF
--- a/packages/backend/convex/web/assignment.ts
+++ b/packages/backend/convex/web/assignment.ts
@@ -14,16 +14,16 @@ import {
 } from "@package/coder-sdk";
 import { createClient } from "@package/coder-sdk/client";
 
+import type { Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import {
   action,
   internalMutation,
   internalQuery,
-  QueryCtx,
   mutation,
   query,
+  QueryCtx,
 } from "../_generated/server";
-import type { Id } from "../_generated/dataModel";
 import { authComponent } from "../auth";
 import { getUserRole } from "../helpers/roles";
 
@@ -261,6 +261,7 @@ export const launchWorkspace = action({
         body: {
           name: `${args.assignmentId.toString()}`,
           template_id: templatesResp.data?.at(0)?.id,
+          ttl_ms: 3600000,
         },
         path: {
           user: coderUserId,


### PR DESCRIPTION
### TL;DR

Added a time-to-live (TTL) parameter to workspace creation and exposed roles helper in the API.

### What changed?

- Added a `ttl_ms` parameter set to 3,600,000 milliseconds (1 hour) when launching workspaces
- Exposed the `helpers/roles` module in the generated API interface
- Made minor import organization changes in the assignment module

### How to test?

1. Launch a workspace through the application
2. Verify that the workspace automatically terminates after 1 hour of inactivity
3. Confirm that any code using the roles helper functions continues to work properly

### Why make this change?

Setting a TTL for workspaces helps manage resources more efficiently by automatically terminating inactive workspaces after a specified period. This prevents unnecessary resource consumption and potential cost overruns. Exposing the roles helper in the API makes these functions more accessible throughout the codebase.