### PR TITLE
feat(web): add assignment submission functionality

### DIFF
--- a/packages/backend/convex/web/assignment.ts
+++ b/packages/backend/convex/web/assignment.ts
@@ -93,6 +93,21 @@ export const getByIds = query({
   },
 });
 
+export const getMyActiveWorkspace = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+    if (!user) {
+      throw new Error("Unauthorized");
+    }
+
+    return ctx.db
+      .query("workspaces")
+      .withIndex("userId_isActive", (q) => q.eq("userId", user._id).eq("isActive", true))
+      .first();
+  },
+});
+
 export const setUserActiveWorkspace = internalMutation({
   args: {
     userId: v.string(),


### PR DESCRIPTION
### TL;DR

Added assignment submission functionality for students with active workspaces.

### What changed?

- Added a "Submit Assignment" button on the student assignment page
- Implemented submission handling with proper validation and error messages
- Added a query to check for a student's active workspace
- Added status messages to guide students through the submission process
- Implemented re-submission capability for already submitted assignments
- Added validation to prevent submissions for past-due assignments

### How to test?

1. Log in as a student
2. Navigate to an assignment page
3. Launch a workspace
4. Click "Submit Assignment" to submit your work
5. Verify the success toast appears
6. Try submitting without an active workspace to see the error message
7. Try submitting a past-due assignment to verify it's blocked
8. Submit an already submitted assignment to test the re-submission flow

### Why make this change?

This change completes the assignment workflow for students by allowing them to submit their work after launching a workspace. It provides clear feedback about submission status and requirements, ensuring students understand when they can submit and what workspace will be used for their submission.