### PR TITLE
refactor(extension): extract ReplayFetcher class and improve test variable scoping

### DIFF
--- a/apps/vscode-extension/src/test/extension.test.ts
+++ b/apps/vscode-extension/src/test/extension.test.ts
@@ -23,10 +23,8 @@ import { activate, BatchedConvexHttpClient } from "../extension";
 suite("Extension Test Suite", () => {
   vscode.window.showInformationMessage("Start all tests.");
 
-  let mockClient: TestConvex<typeof schema>;
-  let workspaceId: Id<"workspaces">;
-  let workspaceUri: vscode.Uri;
   let fileManager: FileManager;
+  let replayFetcher: ReplayFetcher;
 
   suiteSetup(() => {
     /*
@@ -56,23 +54,25 @@ suite("Extension Test Suite", () => {
       "convex/web/replay.ts": () => Promise.resolve(webReplayModule),
       "convex/api/extension.ts": () => Promise.resolve(apiExtensionModule),
     };
-    mockClient = convexTest(schema, modules);
+    const mockClient = convexTest(schema, modules);
 
     await mockClient.mutation(internal.web.index.createMock, {});
 
-    const coderWorkspaceId = "273044a0-03a7-49ef-b1a4-e1bbc3c49d9b";
+    // const coderWorkspaceId = "empty000-work-spac-e000-for00testing";
+    const coderWorkspaceId = "00000000-0000-0000-0000-000000000000";
     const unverifiedWorkspaceId = await mockClient.query(
       internal.web.index.getWorkspaceByCoderWorkspaceId,
       { coderWorkspaceId },
     );
     assert.ok(unverifiedWorkspaceId, "Workspace should exist");
-    workspaceId = unverifiedWorkspaceId;
+    const workspaceId = unverifiedWorkspaceId;
 
     const newWorkspaceUri = vscode.workspace.workspaceFolders?.[0]?.uri;
     assert.ok(newWorkspaceUri, "Workspace folder should exist");
-    workspaceUri = newWorkspaceUri;
+    const workspaceUri = newWorkspaceUri;
 
     fileManager = new FileManager(workspaceUri);
+    replayFetcher = new ReplayFetcher(mockClient, workspaceId);
     BatchedConvexHttpClient.init(
       mockClient as unknown as ConvexHttpClient,
       `coder-${coderWorkspaceId}-7b78cdf4d9-mx66l`,
@@ -97,15 +97,12 @@ suite("Extension Test Suite", () => {
     // we need this to bypass the debounce and flush the buffer
     await BatchedConvexHttpClient.getInstance().flush();
 
-    const replay = await mockClient.query(api.web.replay.getReplay, {
-      workspaceId,
-    });
-    const lastEvent = replay[replay.length - 1];
-    assert.ok(replay.length > 0, "Replay should contain at least one event");
+    const replay = await replayFetcher.fetch(1);
+
     assert.deepStrictEqual(
-      lastEvent,
+      replay[0],
       {
-        ...lastEvent,
+        ...replay[0],
         eventType: WorkspaceEvents.NAME.DID_CHANGE_TEXT_DOCUMENT,
         metadata: {
           contentChanges: [
@@ -139,7 +136,7 @@ suite("Extension Test Suite", () => {
     assert.ok(success1, "First edit should be applied");
 
     // simulate typing delay
-    await sleep(200);
+    await sleep(100);
 
     const success2 = await fileManager.createAndEdit(
       "test-dummy2.ts",
@@ -151,18 +148,9 @@ suite("Extension Test Suite", () => {
     // Flush to bypass debounce and submit batched events
     await BatchedConvexHttpClient.getInstance().flush();
 
-    // Verify both events were received
-    const replay = await mockClient.query(api.web.replay.getReplay, {
-      workspaceId,
-    });
+    const replay = await replayFetcher.fetch(2);
 
-    const recentEvents = replay.slice(-2);
-    assert.ok(
-      recentEvents.length >= 2,
-      "Should have at least 2 sequential events",
-    );
-
-    const firstEditEvent = recentEvents.find((event) => {
+    const firstEditEvent = replay.find((event) => {
       assert.ok(
         event.eventType === WorkspaceEvents.NAME.DID_CHANGE_TEXT_DOCUMENT,
       );
@@ -172,7 +160,7 @@ suite("Extension Test Suite", () => {
     });
     assert.ok(firstEditEvent, "Should find event containing 'First edit'");
 
-    const secondEditEvent = recentEvents.find((event) => {
+    const secondEditEvent = replay.find((event) => {
       assert.ok(
         event.eventType === WorkspaceEvents.NAME.DID_CHANGE_TEXT_DOCUMENT,
       );
@@ -243,5 +231,24 @@ class FileManager {
 
   getFileURI(fileName: string) {
     return vscode.Uri.joinPath(this.workspaceUri, fileName);
+  }
+}
+
+class ReplayFetcher {
+  constructor(
+    private readonly client: TestConvex<typeof schema>,
+    private readonly workspaceId: Id<"workspaces">,
+  ) {}
+
+  async fetch(expectedNumberOfEvents: number) {
+    const replay = await this.client.query(api.web.replay.getReplay, {
+      workspaceId: this.workspaceId,
+    });
+
+    assert.ok(
+      replay.length === expectedNumberOfEvents,
+      `${expectedNumberOfEvents} events should have been added. Got ${JSON.stringify(replay)}`,
+    );
+    return replay;
   }
 }

--- a/packages/backend/convex/web/index.ts
+++ b/packages/backend/convex/web/index.ts
@@ -56,6 +56,13 @@ export const createMock = internalMutation(async (ctx) => {
     userId: "user_123", // sample user that does not exist
   });
 
+  // Empty workspace
+  await ctx.db.insert("workspaces", {
+    coderWorkspaceId: "00000000-0000-0000-0000-000000000000",
+    isActive: true,
+    userId: "user_123",
+  });
+
   // Update classrooms with assignments
   await ctx.db.patch(classroom1Id, {
     assignments: [assignment1Id, assignment2Id],


### PR DESCRIPTION
### TL;DR

Refactored VSCode extension tests to use a dedicated `ReplayFetcher` class and improved test reliability by using exact event count assertions.

### What changed?

- Introduced a new `ReplayFetcher` class that encapsulates replay fetching logic and validates the exact number of expected events
- Converted global test variables (`mockClient`, `workspaceId`, `workspaceUri`) to local scope variables within the setup function
- Replaced manual replay querying and slicing with the new `ReplayFetcher.fetch()` method that takes an expected event count
- Added a new empty workspace with ID "00000000-0000-0000-0000-000000000000" to the mock data setup
- Reduced typing delay simulation from 200ms to 100ms in sequential edit tests

### How to test?

Run the existing VSCode extension test suite. The tests should pass with more reliable assertions about the exact number of events captured during workspace interactions.

### Why make this change?

This refactoring improves test reliability by ensuring exact event counts rather than checking minimum thresholds, reduces code duplication in replay fetching logic, and provides better error messages when event expectations aren't met. The scoping changes also improve test isolation by preventing shared state between test runs.