### PR TITLE
feat: add DID_RENAME_FILES event data ingestion with type-safe handling

### DIFF
--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -67,13 +67,20 @@ export function activate(
   // );
 
   // TODO: workspace ingestion flow implementation for this event is low priority but could potentially be useful
-  // context.subscriptions.push(
-  //   vscode.workspace.onDidRenameFiles((e) => {
-  //     channel.appendLine(
-  //       `[${Date.now()}] ${e.files.map((file) => file.oldUri.fsPath).join(", ")} - ${e.files.map((file) => file.newUri.fsPath).join(", ")} - renamed`,
-  //     );
-  //   }),
-  // );
+  context.subscriptions.push(
+    vscode.workspace.onDidRenameFiles((e) => {
+      BatchedConvexHttpClient.getInstance().addEvent({
+        timestamp: Date.now(),
+        eventType: WorkspaceEvents.NAME.DID_RENAME_FILES,
+        metadata: {
+          renamedFiles: e.files.map((file) => ({
+            oldFilePath: file.oldUri.fsPath,
+            newFilePath: file.newUri.fsPath,
+          })),
+        },
+      });
+    }),
+  );
 
   // TODO: workspace ingestion flow implementation for this event is low priority but could potentially be useful
   // context.subscriptions.push(

--- a/packages/backend/convex/web/index.ts
+++ b/packages/backend/convex/web/index.ts
@@ -457,4 +457,16 @@ const events = [
     },
     timestamp: 1769638583829.0,
   },
+  {
+    eventType: "DID_RENAME_FILES",
+    metadata: {
+      renamedFiles: [
+        {
+          newFilePath: "/Users/fvcci/Code/Github/price-matched/test-renamed.py",
+          oldFilePath: "/Users/fvcci/Code/Github/price-matched/test.py",
+        },
+      ],
+    },
+    timestamp: 1769638614000,
+  },
 ];

--- a/packages/backend/convex/web/replay.ts
+++ b/packages/backend/convex/web/replay.ts
@@ -1,4 +1,5 @@
 import { v } from "convex/values";
+import z from "zod";
 
 import * as WorkspaceEvents from "@package/validators/workspaceEvents";
 
@@ -55,8 +56,6 @@ export const getReplay = query({
       .order("asc")
       .collect();
 
-    return events.map((event) =>
-      WorkspaceEvents.DidChangeTextDocument.parse(event),
-    );
+    return z.array(WorkspaceEvents.WorkspaceEvent).parse(events);
   },
 });

--- a/packages/validators/src/workspaceEvents.ts
+++ b/packages/validators/src/workspaceEvents.ts
@@ -4,23 +4,18 @@
 
 import { z } from "zod";
 
-export const NAMES = ["DID_CHANGE_TEXT_DOCUMENT"] as const;
-
-export const NAME = NAMES.reduce(
-  (acc, name) => {
-    acc[name] = name;
-    return acc;
-  },
-  {} as Record<(typeof NAMES)[number], (typeof NAMES)[number]>,
-);
+export const NAME = {
+  DID_CHANGE_TEXT_DOCUMENT: "DID_CHANGE_TEXT_DOCUMENT",
+  DID_RENAME_FILES: "DID_RENAME_FILES",
+} as const;
 
 const Event = z.object({
   timestamp: z.number(),
   workspaceId: z.string(),
 });
 
-export const DidChangeTextDocument = Event.extend({
-  eventType: z.literal("DID_CHANGE_TEXT_DOCUMENT"),
+const DidChangeTextDocument = Event.extend({
+  eventType: z.literal(NAME.DID_CHANGE_TEXT_DOCUMENT),
   metadata: z.object({
     contentChanges: z.array(
       z.object({
@@ -41,4 +36,19 @@ export const DidChangeTextDocument = Event.extend({
   }),
 });
 
-export type DidChangeTextDocument = z.infer<typeof DidChangeTextDocument>;
+const DidRenameFiles = Event.extend({
+  eventType: z.literal(NAME.DID_RENAME_FILES),
+  metadata: z.object({
+    renamedFiles: z.array(
+      z.object({
+        oldFilePath: z.string(),
+        newFilePath: z.string(),
+      }),
+    ),
+  }),
+});
+
+export const WorkspaceEvent = z.discriminatedUnion("eventType", [
+  DidChangeTextDocument,
+  DidRenameFiles,
+]);


### PR DESCRIPTION
### TL;DR

Added support for `DID_RENAME_FILES` workspace events data ingestion with proper type safety and event handling throughout the application.

### What changed?

- Added `DID_RENAME_FILES` event type to the workspace events validator with schema for tracking old and new file paths
- Updated the workspace event validator to use a discriminated union supporting both `DID_CHANGE_TEXT_DOCUMENT` and `DID_RENAME_FILES` events
- Modified the VSCode extension to capture and send file rename events to the backend
- Enhanced the scrubber component to filter events by type, only processing `DID_CHANGE_TEXT_DOCUMENT` events for file path collection and text reconstruction
- Updated the replay query to parse events using the new discriminated union validator instead of assuming all events are text document changes
- Added sample `DID_RENAME_FILES` event data for testing

### How to test?

#### replay

1. Backup convex db
2. Clear all data in the app component in Convex
3. run the `index.createMock` function in the Convex dashboard
4. go to the workspaces table and copy the `_id` field of the one workspace there
5. run `pnpm dev` in the root directory of the project
6. go to [http://localhost:3000/replay?workspaceId=\<paste-your-workspace-_id-field](http://localhost:3000/replay?workspaceId=%7Bpaste-your-workspace-_id-field%7D)\>
7. Verify that the scrubber component properly handles mixed event types without errors

vscode

1. go to the vscode instance
2. build the vscode extension with `pnpm build`
3. upload the extension
4. modify the db url to use your convex URL
5. reload the window
6. rename a file
7. verify it logs the event

### Why make this change?

This change establishes the foundation for handling multiple types of workspace events beyond just text document changes. The type-safe discriminated union approach ensures proper event handling and prevents runtime errors when processing different event types.

Resolves #232