### PR TITLE
fix: check actual workspace status

### DIFF
--- a/apps/nextjs/src/app/app/actions.ts
+++ b/apps/nextjs/src/app/app/actions.ts
@@ -28,9 +28,6 @@ export async function launchWorkspace(assignmentId: Id<"assignments">) {
   // Next.js automatically sets NODE_ENV to 'development' when running `next dev`
   const isDevelopment = env.NODE_ENV === "development";
 
-  // TODO: artificially wait for 15 seconds to ensure the workspace is up
-  await new Promise((resolve) => setTimeout(resolve, 15000));
-
   // In development, redirect through an intermediate endpoint that sets the cookie
   // The reverse proxy (@package/dev-proxy) serves this page and handles the flow
   // In production, set cookie and redirect directly

--- a/apps/nextjs/src/app/student/classroom/[id]/assignment/[assignmentId]/page.tsx
+++ b/apps/nextjs/src/app/student/classroom/[id]/assignment/[assignmentId]/page.tsx
@@ -28,6 +28,7 @@ import { Separator } from "@package/ui/separator";
 import { Spinner } from "@package/ui/spinner";
 
 import { launchWorkspace } from "~/app/app/actions";
+import { WorkspaceLaunchingOverlay } from "~/components/workspace-launching-overlay";
 import { Authenticated, AuthLoading, Unauthenticated } from "~/lib/auth";
 
 function Content({
@@ -120,6 +121,7 @@ function Content({
 
   return (
     <div className="container mx-auto p-6">
+      <WorkspaceLaunchingOverlay isLaunching={isLaunching} />
       <div className="mb-4">
         <Link
           href={`/student/classroom/${classroomId}`}

--- a/apps/nextjs/src/app/student/classroom/[id]/page.tsx
+++ b/apps/nextjs/src/app/student/classroom/[id]/page.tsx
@@ -20,6 +20,7 @@ import { Separator } from "@package/ui/separator";
 import { Spinner } from "@package/ui/spinner";
 
 import { launchWorkspace } from "~/app/app/actions";
+import { WorkspaceLaunchingOverlay } from "~/components/workspace-launching-overlay";
 import { Authenticated, AuthLoading, Unauthenticated } from "~/lib/auth";
 
 interface Classroom {
@@ -73,6 +74,7 @@ function AssignmentCard({
 
   return (
     <Card>
+      <WorkspaceLaunchingOverlay isLaunching={isLaunching} />
       <CardHeader className="space-y-2">
         <div className="flex items-start justify-between gap-3">
           <div className="space-y-1">

--- a/apps/nextjs/src/components/workspace-launching-overlay.tsx
+++ b/apps/nextjs/src/components/workspace-launching-overlay.tsx
@@ -1,0 +1,23 @@
+import { Spinner } from "@package/ui/spinner";
+
+export function WorkspaceLaunchingOverlay({
+  isLaunching,
+}: {
+  isLaunching: boolean;
+}) {
+  if (!isLaunching) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div className="bg-background flex flex-col items-center gap-4 rounded-lg border p-8 shadow-lg">
+        <Spinner className="size-8" />
+        <div className="text-center">
+          <p className="text-lg font-semibold">Launching workspace</p>
+          <p className="text-muted-foreground text-sm">
+            This should take around 30 seconds...
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/backend/convex/web/assignmentActions.ts
+++ b/packages/backend/convex/web/assignmentActions.ts
@@ -240,6 +240,64 @@ export const launchWorkspace = action({
       throw new Error("Failed to create session key in Coder");
     }
 
+    // Poll until the workspace is ready (build running + agent connected & ready)
+    const POLL_INTERVAL_MS = 2000;
+    const TIMEOUT_MS = 120_000;
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < TIMEOUT_MS) {
+      const poll = await getWorkspaceMetadataByUserAndWorkspaceName({
+        client: coderClient,
+        path: {
+          user: coderUserId,
+          workspacename: `${args.assignmentId.toString()}`,
+        },
+      });
+
+      if (poll.error || !poll.data) {
+        throw new Error("Failed to poll workspace status");
+      }
+
+      const buildStatus = poll.data.latest_build?.status;
+
+      // Fail fast on terminal error states
+      if (buildStatus === "failed" || buildStatus === "canceled") {
+        throw new Error(`Workspace build entered terminal state: ${buildStatus}`);
+      }
+
+      if (buildStatus === "running") {
+        // Check if any agent is connected and ready
+        const agents =
+          poll.data.latest_build?.resources?.flatMap((r) => r.agents ?? []) ??
+          [];
+
+        const hasReadyAgent = agents.some(
+          (a) => a.status === "connected" && a.lifecycle_state === "ready",
+        );
+
+        // Fail fast if an agent hit an error
+        const hasAgentError = agents.some(
+          (a) =>
+            a.lifecycle_state === "start_error" ||
+            a.lifecycle_state === "start_timeout",
+        );
+
+        if (hasReadyAgent) {
+          break;
+        }
+
+        if (hasAgentError) {
+          throw new Error("Workspace agent failed to start");
+        }
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+
+    if (Date.now() - startTime >= TIMEOUT_MS) {
+      throw new Error("Workspace did not become ready within 2 minutes");
+    }
+
     await ctx.runMutation(internal.web.assignment.setUserActiveWorkspace, {
       userId: coderUserId,
       coderWorkspaceId: workspaceMetadata.data.id!,


### PR DESCRIPTION
### TL;DR

Added workspace readiness polling and a loading overlay to improve the workspace launch experience. Fixes #239

### What changed?

- Removed the artificial 15-second delay in the `launchWorkspace` action
- Added proper workspace readiness polling that checks for build status and agent connectivity with a 2-minute timeout
- Created a new `WorkspaceLaunchingOverlay` component that displays a spinner and loading message
- Integrated the loading overlay into both the assignment page and classroom assignment cards

### How to test?

1. Navigate to a student classroom and attempt to launch a workspace from an assignment card
2. Verify the loading overlay appears with the spinner and "Launching workspace" message
3. Confirm the workspace launches successfully once the build is running and agents are ready
4. Test the same flow from the individual assignment page
5. Verify error handling by testing with invalid workspace configurations

### Why make this change?

The previous implementation used an arbitrary 15-second delay which could either be too short (causing premature redirects) or too long (poor user experience). The new approach provides accurate workspace readiness detection while giving users clear visual feedback during the launch process.