### PR TITLE
feat: adding file rename functionality and tests

### DIFF
--- a/apps/nextjs/src/components/scrubber.test.tsx
+++ b/apps/nextjs/src/components/scrubber.test.tsx
@@ -1,7 +1,81 @@
+import type { output } from "zod";
 import { describe, expect, it } from "vitest";
+
+import { WorkspaceEvent as WorkspaceEventSchema } from "@package/validators/workspaceEvents";
 
 import type { Range, TextDocumentPosition } from "./scrubber";
 import { deleteText, insertText } from "./scrubber";
+
+type ReplayEvent = output<typeof WorkspaceEventSchema>;
+
+function createReplayEvent(
+  event: Omit<ReplayEvent, "timestamp" | "workspaceId"> &
+    Partial<Pick<ReplayEvent, "timestamp" | "workspaceId">>,
+): ReplayEvent {
+  return WorkspaceEventSchema.parse({
+    timestamp: 0,
+    workspaceId: "test-workspace",
+    ...event,
+  });
+}
+
+function getVisibleFilePathsFromTimeline(transcript: ReplayEvent[]): string[] {
+  const paths = new Set<string>();
+
+  transcript.forEach((event) => {
+    if (event.eventType === "DID_CHANGE_TEXT_DOCUMENT") {
+      event.metadata.contentChanges.forEach((change) => {
+        paths.add(change.filePath);
+      });
+      return;
+    }
+
+    event.metadata.renamedFiles.forEach((rename) => {
+      paths.delete(rename.oldFilePath);
+      paths.add(rename.newFilePath);
+    });
+  });
+
+  return Array.from(paths);
+}
+
+function replayFileContents(transcript: ReplayEvent[]): Map<string, string> {
+  const fileContents = new Map<string, string[]>();
+
+  transcript.forEach((event) => {
+    if (event.eventType === "DID_CHANGE_TEXT_DOCUMENT") {
+      event.metadata.contentChanges.forEach((change) => {
+        const lines = fileContents.get(change.filePath) ?? [""];
+        const isInsertion =
+          change.range.start.line === change.range.end.line &&
+          change.range.start.column === change.range.end.column;
+
+        if (isInsertion) {
+          insertText(lines, change.range.start, change.text);
+        } else {
+          deleteText(lines, change.range);
+          insertText(lines, change.range.start, change.text);
+        }
+
+        fileContents.set(change.filePath, lines);
+      });
+      return;
+    }
+
+    event.metadata.renamedFiles.forEach((rename) => {
+      const oldLines = fileContents.get(rename.oldFilePath) ?? [""];
+      fileContents.set(rename.newFilePath, [...oldLines]);
+      fileContents.delete(rename.oldFilePath);
+    });
+  });
+
+  return new Map(
+    Array.from(fileContents.entries()).map(([filePath, lines]) => [
+      filePath,
+      lines.join("\n"),
+    ]),
+  );
+}
 
 describe("insertText", () => {
   it("should insert text at the beginning of a line", () => {
@@ -229,5 +303,121 @@ c insertedX`);
       end: { line: 1, column: 3 },
     });
     expect(fileZ.join("\n")).toBe(``);
+  });
+});
+
+describe("rename timeline functionality", () => {
+  it("shows first created file in the timeline at the first event", () => {
+    const timeline: ReplayEvent[] = [
+      createReplayEvent({
+        eventType: "DID_CHANGE_TEXT_DOCUMENT",
+        metadata: {
+          contentChanges: [
+            {
+              filePath: "src/file1.ts",
+              range: {
+                start: { line: 0, column: 0 },
+                end: { line: 0, column: 0 },
+              },
+              text: "const a = 1;",
+            },
+          ],
+        },
+      }),
+    ];
+
+    expect(getVisibleFilePathsFromTimeline(timeline)).toEqual(["src/file1.ts"]);
+  });
+
+  it("keeps old file name before rename and new file name after rename", () => {
+    const events: ReplayEvent[] = [
+      createReplayEvent({
+        eventType: "DID_CHANGE_TEXT_DOCUMENT",
+        metadata: {
+          contentChanges: [
+            {
+              filePath: "src/file1.ts",
+              range: {
+                start: { line: 0, column: 0 },
+                end: { line: 0, column: 0 },
+              },
+              text: "hello",
+            },
+          ],
+        },
+      }),
+      createReplayEvent({
+        eventType: "DID_RENAME_FILES",
+        metadata: {
+          renamedFiles: [
+            {
+              oldFilePath: "src/file1.ts",
+              newFilePath: "src/file2.ts",
+            },
+          ],
+        },
+      }),
+    ];
+
+    expect(getVisibleFilePathsFromTimeline(events.slice(0, 1))).toEqual([
+      "src/file1.ts",
+    ]);
+    expect(getVisibleFilePathsFromTimeline(events)).toEqual(["src/file2.ts"]);
+  });
+
+  it("does not keep old content when old file name is reused after rename", () => {
+    const events: ReplayEvent[] = [
+      createReplayEvent({
+        eventType: "DID_CHANGE_TEXT_DOCUMENT",
+        metadata: {
+          contentChanges: [
+            {
+              filePath: "src/file1.ts",
+              range: {
+                start: { line: 0, column: 0 },
+                end: { line: 0, column: 0 },
+              },
+              text: "const oldValue = 123;",
+            },
+          ],
+        },
+      }),
+      createReplayEvent({
+        eventType: "DID_RENAME_FILES",
+        metadata: {
+          renamedFiles: [
+            {
+              oldFilePath: "src/file1.ts",
+              newFilePath: "src/file2.ts",
+            },
+          ],
+        },
+      }),
+      createReplayEvent({
+        eventType: "DID_CHANGE_TEXT_DOCUMENT",
+        metadata: {
+          contentChanges: [
+            {
+              filePath: "src/file1.ts",
+              range: {
+                start: { line: 0, column: 0 },
+                end: { line: 0, column: 0 },
+              },
+              text: "const newValue = 999;",
+            },
+          ],
+        },
+      }),
+    ];
+
+    const visibleFiles = getVisibleFilePathsFromTimeline(events);
+    expect(visibleFiles).toEqual(
+      expect.arrayContaining(["src/file1.ts", "src/file2.ts"]),
+    );
+
+    const fileContents = replayFileContents(events);
+    expect(fileContents.get("src/file2.ts")).toBe("const oldValue = 123;");
+    expect(fileContents.get("src/file1.ts")).toBe("const newValue = 999;");
+    expect(fileContents.get("src/file1.ts")).not.toContain("oldValue");
   });
 });

--- a/apps/nextjs/src/components/scrubber.tsx
+++ b/apps/nextjs/src/components/scrubber.tsx
@@ -195,31 +195,44 @@ export const TextReplayScrubberComponent: React.FC<TextReplayScrubberProps> = ({
   const eventsToReplay = Math.round((state.value / 100) * totalEvents);
   const displayedUserTranscript = userTranscript?.slice(0, eventsToReplay);
 
-  // Extract all unique file paths from the transcript
-  const allFilePaths = React.useMemo(() => {
+  // Extract file paths visible at the current replay position
+  const currentFilePaths = React.useMemo(() => {
     const paths = new Set<string>();
-    userTranscript?.forEach((event) => {
-      // TODO: implement logic for DID_RENAME_FILES events. ISSUE #233
+    displayedUserTranscript?.forEach((event) => {
       if (event.eventType === WorkspaceEvents.NAME.DID_CHANGE_TEXT_DOCUMENT) {
         event.metadata.contentChanges.forEach((change) => {
           paths.add(change.filePath);
         });
       }
+
+      if (event.eventType === WorkspaceEvents.NAME.DID_RENAME_FILES) {
+        event.metadata.renamedFiles.forEach((rename) => {
+          paths.delete(rename.oldFilePath);
+          paths.add(rename.newFilePath);
+        });
+      }
     });
     return Array.from(paths);
-  }, [userTranscript]);
+  }, [displayedUserTranscript]);
 
   // State that tracks the currently selected file
   const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
 
-  // Set initial file when transcript loads
+  // Set initial file when transcript loads and keep selection valid across rename/time changes
   useEffect(() => {
-    if (!selectedFilePath && allFilePaths.length > 0) {
-      // TODO: fix cascading rendering issue ISSUE #193
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setSelectedFilePath(allFilePaths[0] ?? null);
+    if (currentFilePaths.length === 0) {
+      if (selectedFilePath !== null) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setSelectedFilePath(null);
+      }
+      return;
     }
-  }, [allFilePaths, selectedFilePath]);
+
+    if (!selectedFilePath || !currentFilePaths.includes(selectedFilePath)) {
+      // TODO: fix cascading rendering issue ISSUE #193
+      setSelectedFilePath(currentFilePaths[0] ?? null);
+    }
+  }, [currentFilePaths, selectedFilePath]);
 
   // Automatically switch to file being edited at current replay position
   useEffect(() => {
@@ -246,6 +259,17 @@ export const TextReplayScrubberComponent: React.FC<TextReplayScrubberProps> = ({
         // eslint-disable-next-line react-hooks/set-state-in-effect
         setSelectedFilePath(lastChange.filePath);
       }
+      return;
+    }
+
+    if (!isPlaying && !state.isScrubbing) return;
+
+    const renamedSelectedFile = lastEvent.metadata.renamedFiles.find(
+      (rename) => rename.oldFilePath === selectedFilePath,
+    );
+
+    if (renamedSelectedFile) {
+      setSelectedFilePath(renamedSelectedFile.newFilePath);
     }
   }, [displayedUserTranscript, selectedFilePath, isPlaying, state.isScrubbing]);
 
@@ -253,13 +277,17 @@ export const TextReplayScrubberComponent: React.FC<TextReplayScrubberProps> = ({
   const displayedOutputText = React.useMemo(() => {
     if (!selectedFilePath) return "";
 
-    const lines: string[] = [""];
+    const fileContents = new Map<string, string[]>();
+
+    // Initialize currently visible files with empty content
+    currentFilePaths.forEach((path) => {
+      fileContents.set(path, [""]);
+    });
 
     displayedUserTranscript?.forEach((event) => {
       if (event.eventType === WorkspaceEvents.NAME.DID_CHANGE_TEXT_DOCUMENT) {
         event.metadata.contentChanges.forEach((change) => {
-          // Only apply changes for the currently selected file
-          if (change.filePath !== selectedFilePath) return;
+          const lines = fileContents.get(change.filePath) ?? [""];
 
           const isInsertion =
             change.range.start.line === change.range.end.line &&
@@ -272,12 +300,27 @@ export const TextReplayScrubberComponent: React.FC<TextReplayScrubberProps> = ({
             deleteText(lines, change.range);
             insertText(lines, change.range.start, change.text);
           }
+
+          fileContents.set(change.filePath, lines);
+        });
+        // Currently redundant but for clarity upon futher events being added
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      } else if (event.eventType === WorkspaceEvents.NAME.DID_RENAME_FILES) {
+        event.metadata.renamedFiles.forEach((rename) => {
+          const oldLines = fileContents.get(rename.oldFilePath) ?? [""];
+          const newLines = [...oldLines]; // copy content to new file
+          fileContents.set(rename.newFilePath, newLines);
+          fileContents.set(rename.oldFilePath, [""]); // reset old file to empty
+
+          // remove the oldFilePath from being accessed
+          fileContents.delete(rename.oldFilePath);
         });
       }
     });
 
+    const lines = fileContents.get(selectedFilePath) ?? [""];
     return lines.join("\n");
-  }, [displayedUserTranscript, selectedFilePath]);
+  }, [displayedUserTranscript, selectedFilePath, currentFilePaths]);
 
   // Detect the language from the file path
   const detectedLanguage = React.useMemo(
@@ -309,9 +352,9 @@ export const TextReplayScrubberComponent: React.FC<TextReplayScrubberProps> = ({
 
   return (
     <div className="h-max w-full space-y-4">
-      {allFilePaths.length > 1 && (
-        <div className="border-border bg-muted/30 flex gap-0 overflow-x-auto border p-1">
-          {allFilePaths.map((filePath, index) => {
+      {currentFilePaths.length > 0 && (
+        <div className="flex gap-0 overflow-x-auto border border-gray-200 bg-gray-100 p-1 dark:border-gray-700 dark:bg-gray-900">
+          {currentFilePaths.map((filePath, index) => {
             const fileName = filePath.split("/").pop() ?? filePath;
             const isActive = filePath === selectedFilePath;
             return (


### PR DESCRIPTION
## Resolving Issues
#233 #236

## Description
This pull request implements file rename support in the text replay scrubber component. The changes include:

- Added `ReplayEvent` type definitions for `DID_CHANGE_TEXT_DOCUMENT` and `DID_RENAME_FILES` events
- Implemented `getVisibleFilePathsFromTimeline()` function to track file paths that are visible at any point in the timeline, handling renames by removing old paths and adding new ones
- Added `replayFileContents()` function to replay file content changes while preserving content across renames
- Updated the scrubber component to track currently visible files based on replay position rather than all files in the transcript
- Enhanced file selection logic to handle renamed files by automatically switching to the new file path when the selected file is renamed
- Modified content replay to maintain separate file contents for all visible files and handle file renames by copying content to the new path
- Added comprehensive test coverage for rename functionality, including edge cases like reusing old file names after renames

The file tabs now correctly show only files that exist at the current replay position, and the selected file automatically follows renames during playback.

How to Test
Create a replay as usual (ensuring you update the extension name to your workspace), while changing some file names and adding content. Either access the replay directly, or by submitting and viewing from the teacher view.