### PR TITLE
fix: broken lint & format on main

### DIFF
--- a/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/starter-code-card.test.tsx
+++ b/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/starter-code-card.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Id } from "@package/backend/convex/_generated/dataModel";
 
+import { StarterCodeCard } from "./starter-code-card";
+
 // --- Hoisted mocks (available inside vi.mock factories) ---
 
 const {
@@ -19,11 +21,13 @@ const {
   mockRemoveCode: vi.fn(),
   mockUseQuery: vi.fn(),
   mockToast: { success: vi.fn(), error: vi.fn() },
-  capturedUploadSuccess: { fn: null as ((storageKey: string) => Promise<void>) | null },
+  capturedUploadSuccess: {
+    fn: null as ((storageKey: string) => Promise<void>) | null,
+  },
 }));
 
 vi.mock("convex/react", () => ({
-  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useQuery: (...args: unknown[]) => mockUseQuery(...args) as unknown,
   useAction: (ref: string) => {
     if (ref === "getStarterCodeUploadUrl") return mockGetUploadUrl;
     if (ref === "removeStarterCode") return mockRemoveCode;
@@ -61,8 +65,6 @@ vi.mock("~/components/starter-code-uploader", () => ({
     return <div data-testid="starter-code-uploader">Uploader Mock</div>;
   },
 }));
-
-import { StarterCodeCard } from "./starter-code-card";
 
 // --- Helpers ---
 
@@ -134,6 +136,7 @@ describe("StarterCodeCard", () => {
       render(<StarterCodeCard assignmentId={ASSIGNMENT_ID} />);
 
       // Trigger the onUploadSuccess callback the card passes to the uploader
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       await capturedUploadSuccess.fn!("test/key.zip");
 
       expect(mockSaveKey).toHaveBeenCalledWith({
@@ -153,7 +156,10 @@ describe("StarterCodeCard", () => {
 
     it("calls removeCode after confirmation", async () => {
       const user = userEvent.setup();
-      vi.stubGlobal("confirm", vi.fn(() => true));
+      vi.stubGlobal(
+        "confirm",
+        vi.fn(() => true),
+      );
       mockRemoveCode.mockResolvedValue(undefined);
 
       render(<StarterCodeCard assignmentId={ASSIGNMENT_ID} />);
@@ -175,7 +181,10 @@ describe("StarterCodeCard", () => {
 
     it("does nothing when confirmation is cancelled", async () => {
       const user = userEvent.setup();
-      vi.stubGlobal("confirm", vi.fn(() => false));
+      vi.stubGlobal(
+        "confirm",
+        vi.fn(() => false),
+      );
 
       render(<StarterCodeCard assignmentId={ASSIGNMENT_ID} />);
 
@@ -190,7 +199,10 @@ describe("StarterCodeCard", () => {
 
     it("shows error toast when remove fails", async () => {
       const user = userEvent.setup();
-      vi.stubGlobal("confirm", vi.fn(() => true));
+      vi.stubGlobal(
+        "confirm",
+        vi.fn(() => true),
+      );
       mockRemoveCode.mockRejectedValue(new Error("Delete failed"));
 
       render(<StarterCodeCard assignmentId={ASSIGNMENT_ID} />);
@@ -208,7 +220,10 @@ describe("StarterCodeCard", () => {
 
     it("shows 'Removing...' while remove is in progress", async () => {
       const user = userEvent.setup();
-      vi.stubGlobal("confirm", vi.fn(() => true));
+      vi.stubGlobal(
+        "confirm",
+        vi.fn(() => true),
+      );
 
       let resolveRemove!: () => void;
       mockRemoveCode.mockReturnValue(

--- a/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/starter-code-card.tsx
+++ b/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/starter-code-card.tsx
@@ -21,9 +21,7 @@ export function StarterCodeCard({
   const getUploadUrl = useAction(
     api.web.teacherAssignmentActions.getStarterCodeUploadUrl,
   );
-  const saveKey = useMutation(
-    api.web.teacherAssignments.saveStarterCodeKey,
-  );
+  const saveKey = useMutation(api.web.teacherAssignments.saveStarterCodeKey);
   const removeCode = useAction(
     api.web.teacherAssignmentActions.removeStarterCode,
   );
@@ -39,9 +37,7 @@ export function StarterCodeCard({
       await removeCode({ assignmentId });
       toast.success("Starter code removed");
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to remove",
-      );
+      toast.error(error instanceof Error ? error.message : "Failed to remove");
     } finally {
       setIsRemoving(false);
     }

--- a/apps/nextjs/src/app/teacher/classroom/[id]/assignment/new/page.test.tsx
+++ b/apps/nextjs/src/app/teacher/classroom/[id]/assignment/new/page.test.tsx
@@ -1,9 +1,11 @@
-import { Suspense, act } from "react";
+import { act, Suspense } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Id } from "@package/backend/convex/_generated/dataModel";
+
+import NewAssignmentPage from "./page";
 
 // --- Hoisted mocks ---
 
@@ -111,14 +113,14 @@ vi.mock("~/components/starter-code-uploader", () => ({
   },
 }));
 
-import NewAssignmentPage from "./page";
-
 // --- Helpers ---
 
 const CLASSROOM_ID = "classroom123" as Id<"classrooms">;
 const ASSIGNMENT_ID = "assignment456" as Id<"assignments">;
 
 async function renderPage() {
+  // async needed for act() to flush suspended promises from use()
+  // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     render(
       <Suspense fallback={<div>Loading...</div>}>

--- a/apps/nextjs/vitest.setup.ts
+++ b/apps/nextjs/vitest.setup.ts
@@ -2,7 +2,13 @@ import "@testing-library/jest-dom/vitest";
 
 // Uppy Dashboard uses ResizeObserver which is not available in jsdom
 globalThis.ResizeObserver = class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  observe() {
+    /* noop */
+  }
+  unobserve() {
+    /* noop */
+  }
+  disconnect() {
+    /* noop */
+  }
 };


### PR DESCRIPTION
### TL;DR

Applied ESLint fixes and code formatting improvements to test files and vitest setup

### What changed?

- Fixed import ordering by moving component imports before mock definitions
- Added explicit ESLint disable comment for non-null assertion operator usage
- Improved code formatting for multi-line function calls and object properties
- Added type assertion for `useQuery` mock return value
- Updated ResizeObserver mock methods with explicit noop comments
- Applied consistent formatting to function parameters and object literals

### How to test?

Run the existing test suite to ensure all tests continue passing:

```bash
pnpm test
```

Verify ESLint passes without warnings:

```bash
pnpm run lint
```

### Why make this change?

These changes improve code quality and consistency by addressing ESLint warnings and applying standard formatting rules. The fixes ensure better maintainability and adherence to the project's coding standards without affecting functionality.