### PR TITLE
fix: force update

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -54,6 +54,11 @@ jobs:
           files: apps/vscode-extension/*.vsix
           generate_release_notes: true
 
+      - name: Move latest tag to current commit
+        run: |
+          git tag -f vscode-extension-latest
+          git push -f origin vscode-extension-latest
+
       - name: Update latest release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
### TL;DR

Added automatic tagging of the latest commit with `vscode-extension-latest` tag during the VS Code extension release workflow.

### What changed?

The GitHub workflow now includes a step that moves the `vscode-extension-latest` tag to point to the current commit and force pushes it to the remote repository. This happens after the release artifacts are uploaded but before updating the latest release.

### How to test?

Trigger the VS Code extension release workflow and verify that:
1. The `vscode-extension-latest` tag is created/updated to point to the release commit
2. The tag is successfully pushed to the remote repository
3. The workflow completes without errors

### Why make this change?

This ensures there's always a stable reference point (`vscode-extension-latest` tag) that points to the most recent VS Code extension release, making it easier for users and automated systems to reference the latest stable version.