### PR TITLE
feat(web): migrate tables to AG Grid

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -31,6 +31,8 @@
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",
     "@uppy/react": "^5.2.0",
+    "ag-grid-community": "^35.1.0",
+    "ag-grid-react": "^35.1.0",
     "better-auth": "1.4.9",
     "clsx": "^2.1.1",
     "convex": "^1.29.0",

--- a/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/page.tsx
+++ b/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ColDef } from "ag-grid-community";
 import { use, useEffect, useState } from "react";
 import Link from "next/link";
 import { useMutation, useQuery } from "convex/react";
@@ -29,6 +30,7 @@ import { Label } from "@package/ui/label";
 import { Separator } from "@package/ui/separator";
 import { Spinner } from "@package/ui/spinner";
 
+import { AppDataGrid } from "~/components/app-data-grid";
 import { Editor } from "~/components/editor";
 import { MarkdownViewer } from "~/components/markdown-viewer";
 import { Authenticated, AuthLoading, Unauthenticated } from "~/lib/auth";
@@ -149,6 +151,75 @@ function AssignmentContent({
       .length ?? 0;
   const sortedSubmissions =
     submissions?.slice().sort((a, b) => b.submittedAt - a.submittedAt) ?? [];
+  const submissionRows = sortedSubmissions.map((submission) => {
+    const studentName =
+      submission.studentName ??
+      submission.studentEmail?.split("@")[0] ??
+      submission.studentId;
+
+    return {
+      grade: submission.grade ?? null,
+      href: `/teacher/classroom/${classroomId}/assignment/${assignmentId}/review/${submission._id}`,
+      studentLabel: `${studentName} ${submission.studentEmail ?? ""} ${submission.studentId}`,
+      studentName,
+      submittedAtIso: new Date(submission.submittedAt).toISOString(),
+    };
+  });
+  const submissionColumnDefs: ColDef<(typeof submissionRows)[number]>[] = [
+    {
+      field: "studentLabel",
+      headerName: "Student",
+      minWidth: 240,
+      cellRenderer: ({ data }: { data?: (typeof submissionRows)[number] }) =>
+        data ? <p className="font-medium">{data.studentName}</p> : null,
+    },
+    {
+      field: "submittedAtIso",
+      headerName: "Submitted",
+      minWidth: 220,
+      sort: "desc",
+      valueFormatter: ({ value }) =>
+        typeof value === "string" ? new Date(value).toLocaleString() : "",
+    },
+    {
+      field: "grade",
+      headerName: "Grade",
+      filter: "agNumberColumnFilter",
+      flex: 0,
+      maxWidth: 150,
+      minWidth: 120,
+      valueFormatter: ({ value }) =>
+        typeof value === "number" ? `${value}` : "Not graded",
+      cellRenderer: ({
+        value,
+      }: {
+        value?: (typeof submissionRows)[number]["grade"];
+      }) =>
+        typeof value === "number" ? (
+          <span className="font-medium">{value}</span>
+        ) : (
+          <span className="text-muted-foreground">Not graded</span>
+        ),
+    },
+    {
+      colId: "actions",
+      headerName: "Actions",
+      filter: false,
+      flex: 0,
+      maxWidth: 150,
+      minWidth: 130,
+      resizable: false,
+      sortable: false,
+      cellRenderer: ({ data }: { data?: (typeof submissionRows)[number] }) =>
+        data ? (
+          <div className="flex h-full items-center justify-end">
+            <Button asChild size="sm" variant="outline">
+              <Link href={data.href}>Review</Link>
+            </Button>
+          </div>
+        ) : null,
+    },
+  ];
 
   return (
     <div className="container mx-auto p-6">
@@ -213,78 +284,11 @@ function AssignmentContent({
               <div className="flex min-h-[120px] items-center justify-center">
                 <Spinner />
               </div>
-            ) : submissions.length === 0 ? (
-              <Card>
-                <CardContent className="text-muted-foreground py-10 text-center text-sm">
-                  No submissions yet from enrolled students.
-                </CardContent>
-              </Card>
             ) : (
-              <Card>
-                <CardContent className="p-0">
-                  <div className="overflow-x-auto">
-                    <table className="w-full min-w-[720px] text-sm">
-                      <thead className="bg-muted/40">
-                        <tr className="border-b">
-                          <th className="px-4 py-3 text-left font-medium">
-                            Student
-                          </th>
-                          <th className="px-4 py-3 text-left font-medium">
-                            Submitted
-                          </th>
-                          <th className="px-4 py-3 text-left font-medium">
-                            Grade
-                          </th>
-                          <th className="px-4 py-3 text-right font-medium">
-                            Actions
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {sortedSubmissions.map((submission) => (
-                          <tr
-                            key={submission._id}
-                            className="border-b last:border-b-0"
-                          >
-                            <td className="px-4 py-3 align-top">
-                              <p className="font-medium">
-                                {submission.studentName ??
-                                  submission.studentEmail?.split("@")[0] ??
-                                  submission.studentId}
-                              </p>
-                            </td>
-                            <td className="text-muted-foreground px-4 py-3 align-top">
-                              {new Date(
-                                submission.submittedAt,
-                              ).toLocaleString()}
-                            </td>
-                            <td className="px-4 py-3 align-top">
-                              {submission.grade !== undefined ? (
-                                <span className="font-medium">
-                                  {submission.grade}
-                                </span>
-                              ) : (
-                                <span className="text-muted-foreground">
-                                  Not graded
-                                </span>
-                              )}
-                            </td>
-                            <td className="px-4 py-3 text-right align-top">
-                              <Button asChild variant="outline">
-                                <Link
-                                  href={`/teacher/classroom/${classroomId}/assignment/${assignmentId}/review/${submission._id}`}
-                                >
-                                  Review
-                                </Link>
-                              </Button>
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                </CardContent>
-              </Card>
+              <AppDataGrid
+                columnDefs={submissionColumnDefs}
+                rowData={submissionRows}
+              />
             )}
           </section>
         </div>

--- a/apps/nextjs/src/app/teacher/classroom/[id]/page.tsx
+++ b/apps/nextjs/src/app/teacher/classroom/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ColDef } from "ag-grid-community";
 import { use, useState } from "react";
 import Link from "next/link";
 import { useMutation, useQuery } from "convex/react";
@@ -18,6 +19,7 @@ import {
 import { Separator } from "@package/ui/separator";
 import { Spinner } from "@package/ui/spinner";
 
+import { AppDataGrid } from "~/components/app-data-grid";
 import { Authenticated, AuthLoading, Unauthenticated } from "~/lib/auth";
 
 function ClassroomContent({ classroomId }: { classroomId: Id<"classrooms"> }) {
@@ -36,13 +38,7 @@ function ClassroomContent({ classroomId }: { classroomId: Id<"classrooms"> }) {
     );
   }
 
-  const {
-    classroom,
-    assignments,
-    studentCount,
-    pendingEnrollments,
-    enrolledStudents,
-  } = classroomDetails;
+  const { classroom, assignments, enrolledStudents } = classroomDetails;
 
   const handleRemoveStudent = async (studentId: string) => {
     try {
@@ -57,6 +53,119 @@ function ClassroomContent({ classroomId }: { classroomId: Id<"classrooms"> }) {
       );
     }
   };
+
+  const assignmentRows = assignments.map((assignment) => ({
+    assignmentName: assignment.name,
+    dueDateIso: new Date(assignment.dueDate).toISOString(),
+    href: `/teacher/classroom/${classroomId}/assignment/${assignment._id}`,
+  }));
+  const assignmentColumnDefs: ColDef<(typeof assignmentRows)[number]>[] = [
+    {
+      field: "assignmentName",
+      headerName: "Assignment",
+      minWidth: 240,
+    },
+    {
+      field: "dueDateIso",
+      headerName: "Due",
+      minWidth: 220,
+      valueFormatter: ({ value }) =>
+        typeof value === "string" ? new Date(value).toLocaleString() : "",
+    },
+    {
+      colId: "actions",
+      headerName: "Actions",
+      filter: false,
+      flex: 0,
+      maxWidth: 140,
+      minWidth: 120,
+      resizable: false,
+      sortable: false,
+      cellRenderer: ({ data }: { data?: (typeof assignmentRows)[number] }) =>
+        data ? (
+          <div className="flex h-full items-center justify-end">
+            <Button asChild size="sm" variant="outline">
+              <Link href={data.href}>Open</Link>
+            </Button>
+          </div>
+        ) : null,
+    },
+  ];
+
+  const enrolledStudentRows = enrolledStudents.map((enrollment) => {
+    const studentName =
+      enrollment.studentName ??
+      enrollment.studentEmail?.split("@")[0] ??
+      "Unnamed student";
+
+    return {
+      joinedIso: new Date(enrollment._creationTime).toISOString(),
+      studentEmail: enrollment.studentEmail ?? "No email available",
+      studentId: enrollment.studentId,
+      studentLabel: `${studentName} ${enrollment.studentEmail ?? ""} ${enrollment.studentId}`,
+      studentName,
+    };
+  });
+  const enrolledStudentColumnDefs: ColDef<
+    (typeof enrolledStudentRows)[number]
+  >[] = [
+    {
+      field: "studentLabel",
+      headerName: "Student",
+      minWidth: 260,
+      cellRenderer: ({
+        data,
+      }: {
+        data?: (typeof enrolledStudentRows)[number];
+      }) =>
+        data ? (
+          <div className="py-2">
+            <p className="font-medium">{data.studentName}</p>
+            <p className="text-muted-foreground font-mono text-xs">
+              {data.studentId}
+            </p>
+          </div>
+        ) : null,
+    },
+    {
+      field: "studentEmail",
+      headerName: "Email",
+      minWidth: 240,
+    },
+    {
+      field: "joinedIso",
+      headerName: "Joined",
+      minWidth: 220,
+      valueFormatter: ({ value }) =>
+        typeof value === "string" ? new Date(value).toLocaleString() : "",
+    },
+    {
+      colId: "actions",
+      headerName: "Actions",
+      filter: false,
+      flex: 0,
+      maxWidth: 150,
+      minWidth: 130,
+      resizable: false,
+      sortable: false,
+      cellRenderer: ({
+        data,
+      }: {
+        data?: (typeof enrolledStudentRows)[number];
+      }) =>
+        data ? (
+          <div className="flex h-full items-center justify-end">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => handleRemoveStudent(data.studentId)}
+            >
+              Remove
+            </Button>
+          </div>
+        ) : null,
+    },
+  ];
 
   const handleDeleteClassroom = async () => {
     if (!confirm("Delete classroom and all related assignments/submissions?")) {
@@ -106,27 +215,6 @@ function ClassroomContent({ classroomId }: { classroomId: Id<"classrooms"> }) {
         </div>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-3">
-        <Card>
-          <CardHeader>
-            <CardDescription>Assignments</CardDescription>
-            <CardTitle>{assignments.length}</CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardDescription>Enrolled Students</CardDescription>
-            <CardTitle>{studentCount}</CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardDescription>Pending Enrollments</CardDescription>
-            <CardTitle>{pendingEnrollments.length}</CardTitle>
-          </CardHeader>
-        </Card>
-      </div>
-
       <Separator />
 
       <section className="space-y-3">
@@ -138,49 +226,10 @@ function ClassroomContent({ classroomId }: { classroomId: Id<"classrooms"> }) {
             </CardContent>
           </Card>
         ) : (
-          <Card>
-            <CardContent className="p-0">
-              <div className="overflow-x-auto">
-                <table className="w-full min-w-[720px] text-sm">
-                  <thead className="bg-muted/40">
-                    <tr className="border-b">
-                      <th className="px-4 py-3 text-left font-medium">
-                        Assignment
-                      </th>
-                      <th className="px-4 py-3 text-left font-medium">Due</th>
-                      <th className="px-4 py-3 text-right font-medium">
-                        Actions
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {assignments.map((assignment) => (
-                      <tr
-                        key={assignment._id}
-                        className="border-b last:border-b-0"
-                      >
-                        <td className="px-4 py-3 align-top font-medium">
-                          {assignment.name}
-                        </td>
-                        <td className="text-muted-foreground px-4 py-3 align-top">
-                          {new Date(assignment.dueDate).toLocaleString()}
-                        </td>
-                        <td className="px-4 py-3 text-right align-top">
-                          <Button asChild variant="outline">
-                            <Link
-                              href={`/teacher/classroom/${classroomId}/assignment/${assignment._id}`}
-                            >
-                              Open
-                            </Link>
-                          </Button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </CardContent>
-          </Card>
+          <AppDataGrid
+            columnDefs={assignmentColumnDefs}
+            rowData={assignmentRows}
+          />
         )}
       </section>
 
@@ -193,63 +242,11 @@ function ClassroomContent({ classroomId }: { classroomId: Id<"classrooms"> }) {
             </CardContent>
           </Card>
         ) : (
-          <Card>
-            <CardContent className="p-0">
-              <div className="overflow-x-auto">
-                <table className="w-full min-w-[720px] text-sm">
-                  <thead className="bg-muted/40">
-                    <tr className="border-b">
-                      <th className="px-4 py-3 text-left font-medium">
-                        Student
-                      </th>
-                      <th className="px-4 py-3 text-left font-medium">Email</th>
-                      <th className="px-4 py-3 text-left font-medium">
-                        Joined
-                      </th>
-                      <th className="px-4 py-3 text-right font-medium">
-                        Actions
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {enrolledStudents.map((enrollment) => (
-                      <tr
-                        key={enrollment._id}
-                        className="border-b last:border-b-0"
-                      >
-                        <td className="px-4 py-3 align-top">
-                          <p className="font-medium">
-                            {enrollment.studentName ??
-                              enrollment.studentEmail?.split("@")[0] ??
-                              "Unnamed student"}
-                          </p>
-                          <p className="text-muted-foreground font-mono text-xs">
-                            {enrollment.studentId}
-                          </p>
-                        </td>
-                        <td className="text-muted-foreground px-4 py-3 align-top">
-                          {enrollment.studentEmail ?? "No email available"}
-                        </td>
-                        <td className="text-muted-foreground px-4 py-3 align-top">
-                          {new Date(enrollment._creationTime).toLocaleString()}
-                        </td>
-                        <td className="px-4 py-3 text-right align-top">
-                          <Button
-                            variant="outline"
-                            onClick={() =>
-                              handleRemoveStudent(enrollment.studentId)
-                            }
-                          >
-                            Remove
-                          </Button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </CardContent>
-          </Card>
+          <AppDataGrid
+            columnDefs={enrolledStudentColumnDefs}
+            rowData={enrolledStudentRows}
+            rowHeight={72}
+          />
         )}
       </section>
     </div>

--- a/apps/nextjs/src/components/app-data-grid.tsx
+++ b/apps/nextjs/src/components/app-data-grid.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { ColDef, Module } from "ag-grid-community";
+import { AllCommunityModule } from "ag-grid-community";
+import { AgGridReact } from "ag-grid-react";
+
+import { cn } from "@package/ui";
+import { useTheme } from "@package/ui/theme";
+
+const gridModules: Module[] = [AllCommunityModule];
+const defaultColDef: ColDef = {
+  sortable: true,
+  filter: true,
+  floatingFilter: true,
+  resizable: true,
+  flex: 1,
+  minWidth: 140,
+};
+
+interface AppDataGridProps<TData> {
+  columnDefs: ColDef<TData>[];
+  rowData: TData[];
+  className?: string;
+  minWidthClassName?: string;
+  rowHeight?: number;
+}
+
+export function AppDataGrid<TData>({
+  columnDefs,
+  rowData,
+  className,
+  minWidthClassName = "min-w-[720px]",
+  rowHeight = 56,
+}: AppDataGridProps<TData>) {
+  const theme = useTheme();
+
+  return (
+    <div
+      className="overflow-x-auto"
+      data-ag-theme-mode={
+        theme.resolvedTheme === "dark" ? "dark-blue" : "light"
+      }
+    >
+      <AgGridReact<TData>
+        animateRows
+        className={cn("w-full", minWidthClassName, className)}
+        columnDefs={columnDefs}
+        containerStyle={{ width: "100%" }}
+        defaultColDef={defaultColDef}
+        domLayout="autoHeight"
+        headerHeight={44}
+        modules={gridModules}
+        overlayNoRowsTemplate="<span class='text-sm'>No rows to display.</span>"
+        rowData={rowData}
+        rowHeight={rowHeight}
+        suppressCellFocus
+      />
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,12 @@ importers:
       '@uppy/react':
         specifier: ^5.2.0
         version: 5.2.0(@uppy/core@5.2.0)(@uppy/dashboard@5.1.1(@uppy/core@5.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      ag-grid-community:
+        specifier: ^35.1.0
+        version: 35.1.0
+      ag-grid-react:
+        specifier: ^35.1.0
+        version: 35.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       better-auth:
         specifier: 1.4.9
         version: 1.4.9(next@16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@22.18.12)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0))
@@ -3884,6 +3890,18 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ag-charts-types@13.1.0:
+    resolution: {integrity: sha512-DytRM3CXli+Y013SC1Mr8lQBrhVTACK+11ilDHOhwUM0sRpmGuR51XFGcBKOliW1Vas1AycP31Cm3Pp0jx3hqw==}
+
+  ag-grid-community@35.1.0:
+    resolution: {integrity: sha512-yWFQfRNjv3KUBkHHzFdDOYGjPcDMU0B8Up4qG651diFlGRUGEGVs94SK73niWvk1FDZdpV9oWrwq3f30/qAoVg==}
+
+  ag-grid-react@35.1.0:
+    resolution: {integrity: sha512-n8pJh4RTpos8stzz91nEhTCZZdLy9bjQYAGxIxJ8ocVagnEsAk9T5Vz/VEKUhOGz36il68n7TVbVWSuUA3a+mg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -4041,6 +4059,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   better-auth@1.4.9:
     resolution: {integrity: sha512-usSdjuyTzZwIvM8fjF8YGhPncxV3MAg3dHUO9uPUnf0yklXUSYISiH1+imk6/Z+UBqsscyyPRnbIyjyK97p7YA==}
@@ -11206,6 +11225,19 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  ag-charts-types@13.1.0: {}
+
+  ag-grid-community@35.1.0:
+    dependencies:
+      ag-charts-types: 13.1.0
+
+  ag-grid-react@35.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      ag-grid-community: 35.1.0
+      prop-types: 15.8.1
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   agent-base@7.1.4: {}
 


### PR DESCRIPTION
## What Changed

Replaced all HTML tables with AG Grid data grids. This ensure a consistent style across our tables and enables features such as sorting and filtering across fields. We also remove unused stat cards.

The tables are blue pending the upcoming theme change for the app.

## Comparison

| Page | Before | After |
| --- | --- | --- |
| Classroom Page | ![image.png](https://app.graphite.com/user-attachments/assets/d13f4837-82f3-46d4-96bb-b71cb157d345.png) | ![image.png](https://app.graphite.com/user-attachments/assets/8ab2791b-5943-4885-80c1-40dfb1fad81a.png) |
| Assignment Page | ![image.png](https://app.graphite.com/user-attachments/assets/54eaa0ef-9fe6-4c5a-922c-0e432b43bb82.png) | ![image.png](https://app.graphite.com/user-attachments/assets/cdbf1ce9-2ed3-4665-b7d5-1e3cb1b24327.png) |

