### PR TITLE
feat(web): Add numeric grade validation for teachers and remove arrows from numeric input

### DIFF
--- a/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/page.tsx
+++ b/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/page.tsx
@@ -246,14 +246,14 @@ function AssignmentContent({
       maxWidth: 150,
       minWidth: 120,
       valueFormatter: ({ value }) =>
-        typeof value === "number" ? `${value}` : "Not graded",
+        typeof value === "number" ? `${value}%` : "Not graded",
       cellRenderer: ({
         value,
       }: {
         value?: (typeof submissionRows)[number]["grade"];
       }) =>
         typeof value === "number" ? (
-          <span className="font-medium">{value}</span>
+          <span className="font-medium">{value}%</span>
         ) : (
           <span className="text-muted-foreground">Not graded</span>
         ),
@@ -500,6 +500,7 @@ function AssignmentContent({
                           0,
                         ) / gradedCount
                     ).toFixed(1)}
+                    %
                   </span>
                 </div>
               ) : null}

--- a/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/review/[submissionId]/page.tsx
+++ b/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/review/[submissionId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useCallback, useMemo, useState } from "react";
+import { use, useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useMutation, useQuery } from "convex/react";
@@ -31,13 +31,29 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@package/ui/dropdown-menu";
-import { Input } from "@package/ui/input";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+} from "@package/ui/input-group";
 import { Label } from "@package/ui/label";
 import { Separator } from "@package/ui/separator";
 import { Spinner } from "@package/ui/spinner";
 
 import { TextReplayScrubberComponent } from "~/components/scrubber";
 import { Authenticated, AuthLoading, Unauthenticated } from "~/lib/auth";
+
+function sanitizeGradeInput(value: string) {
+  const digitsAndDotsOnly = value.replace(/[^\d.]/g, "");
+  const [whole = "", ...decimalParts] = digitsAndDotsOnly.split(".");
+
+  if (decimalParts.length === 0) {
+    return whole;
+  }
+
+  return `${whole}.${decimalParts.join("")}`;
+}
 
 function ReviewContent({
   classroomId,
@@ -81,7 +97,7 @@ function ReviewContent({
         : "all";
     },
   );
-
+  const [showOverHundredConfirm, setShowOverHundredConfirm] = useState(false);
   const studentDisplayName =
     submission?.studentName ??
     submission?.studentEmail?.split("@")[0] ??
@@ -146,6 +162,24 @@ function ReviewContent({
     return null;
   }, [currentSubmissionIndex, matchesActiveFilter, sortedSubmissions]);
 
+  useEffect(() => {
+    if (!showOverHundredConfirm) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setShowOverHundredConfirm(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [showOverHundredConfirm]);
+
   if (assignment === undefined || submission === undefined) {
     return (
       <div className="flex min-h-80 items-center justify-center">
@@ -157,19 +191,7 @@ function ReviewContent({
   const displayGrade = newGrade ?? submission.grade?.toString() ?? "";
   const displayFeedback = newFeedback ?? submission.submissionFeedback ?? "";
 
-  const handleSave = async () => {
-    const nextGrade =
-      displayGrade.trim() === ""
-        ? null
-        : Number.isNaN(Number(displayGrade))
-          ? Number.NaN
-          : Number(displayGrade);
-
-    if (Number.isNaN(nextGrade)) {
-      toast.error("Grade must be a valid number");
-      return;
-    }
-
+  const saveReview = async (nextGrade: number | null) => {
     setIsSaving(true);
     try {
       const promises = [];
@@ -201,257 +223,349 @@ function ReviewContent({
     }
   };
 
+  const handleSave = async () => {
+    if (displayGrade.trim() === "") {
+      toast.error("Grade is required");
+      return;
+    }
+
+    const nextGrade = Number.isNaN(Number(displayGrade))
+      ? Number.NaN
+      : Number(displayGrade);
+
+    if (Number.isNaN(nextGrade)) {
+      toast.error("Grade must be a valid number");
+      return;
+    }
+
+    if (nextGrade < 0) {
+      toast.error("Grade must be 0 or higher");
+      return;
+    }
+
+    if (nextGrade > 100) {
+      setShowOverHundredConfirm(true);
+      return;
+    }
+
+    await saveReview(nextGrade);
+  };
+
   return (
-    <div className="container mx-auto p-6">
-      <div className="mb-4 flex items-center justify-between gap-2">
-        <Link
-          href={`/teacher/classroom/${classroomId}/assignment/${assignmentId}`}
-          className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm transition-colors"
+    <>
+      {showOverHundredConfirm ? (
+        <div
+          className="bg-background/80 fixed inset-0 z-50 flex items-center justify-center p-4"
+          onClick={(event) => {
+            if (event.target === event.currentTarget) {
+              setShowOverHundredConfirm(false);
+            }
+          }}
         >
-          <ArrowLeft className="h-4 w-4" />
-          Back to Assignment
-        </Link>
-      </div>
-
-      <div className="mb-4 flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <Button
-            variant="default"
-            size="lg"
-            asChild={Boolean(previousSubmission)}
-            disabled={!previousSubmission}
-            className={cn(
-              "w-32 px-6 whitespace-nowrap",
-              !previousSubmission && "opacity-50",
-            )}
-          >
-            {previousSubmission ? (
-              <Link
-                href={`/teacher/classroom/${classroomId}/assignment/${assignmentId}/review/${previousSubmission._id}?filter=${filterMode}`}
-                className="flex items-center gap-2"
-              >
-                <ChevronLeft className="h-4 w-4" />
-                Previous
-              </Link>
-            ) : (
-              <span className="flex items-center gap-2">
-                <ChevronLeft className="h-4 w-4" />
-                Previous
-              </span>
-            )}
-          </Button>
-          <Button
-            variant="default"
-            size="lg"
-            asChild={Boolean(nextSubmission)}
-            disabled={!nextSubmission}
-            className={cn(
-              "w-32 px-6 whitespace-nowrap",
-              !nextSubmission && "opacity-50",
-            )}
-          >
-            {nextSubmission ? (
-              <Link
-                href={`/teacher/classroom/${classroomId}/assignment/${assignmentId}/review/${nextSubmission._id}?filter=${filterMode}`}
-                className="flex items-center gap-2"
-              >
-                Next
-                <ChevronRight className="h-4 w-4" />
-              </Link>
-            ) : (
-              <span className="flex items-center gap-2">
-                Next
-                <ChevronRight className="h-4 w-4" />
-              </span>
-            )}
-          </Button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant={filterMode === "all" ? "outline" : "default"}
-                size="lg"
-                className="gap-2"
-              >
-                <Filter className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start">
-              <DropdownMenuItem
-                onClick={() => setFilterMode("all")}
-                className={cn(filterMode === "all" && "bg-muted")}
-              >
-                All Submissions
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => setFilterMode("ungraded")}
-                className={cn(filterMode === "ungraded" && "bg-muted")}
-              >
-                Ungraded
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => setFilterMode("flagged")}
-                className={cn(filterMode === "flagged" && "bg-muted")}
-              >
-                Flagged
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
-
-      <div className="mb-6 space-y-1">
-        <h1 className="text-3xl font-bold">Review Submission</h1>
-        <p className="text-muted-foreground text-sm">
-          {assignment.name} • {studentDisplayName}
-        </p>
-      </div>
-
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
-        <div className="space-y-6">
-          <Card>
+          <Card className="w-full max-w-md shadow-lg">
             <CardHeader>
-              <CardTitle>Submission Details</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2 text-sm">
-              <div className="flex justify-between gap-4">
-                <span className="text-muted-foreground">Student</span>
-                <span className="font-medium">{studentDisplayName}</span>
-              </div>
-              <div className="flex justify-between gap-4">
-                <span className="text-muted-foreground">Current Grade</span>
-                <span className="font-medium">
-                  {submission.grade ?? "Not graded"}
-                </span>
-              </div>
-              <div className="flex justify-between gap-4">
-                <span className="text-muted-foreground">Workspace</span>
-                <span className="font-mono text-xs">
-                  {submission.workspaceId ?? "Not linked"}
-                </span>
-              </div>
-              <div className="flex justify-between gap-4">
-                <span className="text-muted-foreground">Published</span>
-                <span className="font-medium">
-                  {submission.gradesReleased ? (
-                    <span className="text-accent-foreground inline-flex items-center gap-1">
-                      <CheckCircle2 className="h-3 w-3" />
-                      Yes
-                    </span>
-                  ) : (
-                    "No"
-                  )}
-                </span>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <div className="flex justify-between pr-6">
-              <CardHeader className="flex-1">
-                <CardTitle>Replay</CardTitle>
-                <CardDescription>
-                  Scrub through the workspace edit history for this submission.
-                </CardDescription>
-              </CardHeader>
-              <div>
-                <Button
-                  className={cn("gap-2 font-medium text-white transition-all", {
-                    "bg-red-800 hover:bg-blue-500": submission.flagged,
-                    "bg-red-700 hover:bg-red-600": !submission.flagged,
-                  })}
-                  onClick={() =>
-                    toggleSubmissionFlag({ submissionId: submission._id })
-                  }
-                >
-                  <Flag className="h-4 w-4" />
-                  {submission.flagged ? "Unflag Submission" : "Flag Submission"}
-                </Button>
-              </div>
-            </div>
-            <CardContent>
-              {submission.workspaceId ? (
-                <TextReplayScrubberComponent
-                  workspaceId={submission.workspaceId}
-                />
-              ) : (
-                <p className="text-muted-foreground text-sm">
-                  No workspace is attached to this submission, so replay is
-                  unavailable.
-                </p>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-
-        <div className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Grading</CardTitle>
+              <CardTitle>Save Grade Above 100?</CardTitle>
+              <CardDescription>
+                This grade is higher than 100. Confirm if you want to save it
+                anyway.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="review-grade">Grade</Label>
-                <Input
-                  id="review-grade"
-                  value={displayGrade}
-                  onChange={(event) => setNewGrade(event.target.value)}
-                  placeholder="e.g. 95"
-                  type="number"
-                  step="0.01"
-                />
+              <div className="bg-muted rounded-md px-3 py-2 text-sm">
+                Grade to save:{" "}
+                <span className="font-medium">{displayGrade}</span>
               </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="review-feedback">Feedback</Label>
-                <textarea
-                  id="review-feedback"
-                  rows={6}
-                  value={displayFeedback}
-                  onChange={(event) => setNewFeedback(event.target.value)}
-                  placeholder="Feedback for the student"
-                  className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[140px] w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                />
+              <div className="flex justify-end gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => setShowOverHundredConfirm(false)}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={async () => {
+                    setShowOverHundredConfirm(false);
+                    await saveReview(Number(displayGrade));
+                  }}
+                  disabled={isSaving}
+                >
+                  Confirm Save
+                </Button>
               </div>
-
-              <Button
-                className="w-full"
-                onClick={handleSave}
-                disabled={isSaving}
-              >
-                {isSaving ? "Saving..." : "Save Grade & Feedback"}
-              </Button>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Status</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm">
-              <div className="flex justify-between gap-4">
-                <span className="text-muted-foreground">Current Grade</span>
-                <span className="font-medium">
-                  {submission.grade ?? "Not graded"}
-                </span>
-              </div>
-              <div className="flex justify-between gap-4">
-                <span className="text-muted-foreground">Graded At</span>
-                <span className="font-medium">
-                  {submission.gradedAt
-                    ? new Date(submission.gradedAt).toLocaleString()
-                    : "Not graded"}
-                </span>
-              </div>
-              <Separator />
-              <p className="text-muted-foreground text-xs">
-                Feedback and grade are saved independently, so you can update
-                either field at any time.
-              </p>
             </CardContent>
           </Card>
         </div>
+      ) : null}
+
+      <div className="container mx-auto p-6">
+        <div className="mb-4 flex items-center justify-between gap-2">
+          <Link
+            href={`/teacher/classroom/${classroomId}/assignment/${assignmentId}`}
+            className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Assignment
+          </Link>
+        </div>
+
+        <div className="mb-4 flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Button
+              variant="default"
+              size="lg"
+              asChild={Boolean(previousSubmission)}
+              disabled={!previousSubmission}
+              className={cn(
+                "w-32 px-6 whitespace-nowrap",
+                !previousSubmission && "opacity-50",
+              )}
+            >
+              {previousSubmission ? (
+                <Link
+                  href={`/teacher/classroom/${classroomId}/assignment/${assignmentId}/review/${previousSubmission._id}?filter=${filterMode}`}
+                  className="flex items-center gap-2"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Previous
+                </Link>
+              ) : (
+                <span className="flex items-center gap-2">
+                  <ChevronLeft className="h-4 w-4" />
+                  Previous
+                </span>
+              )}
+            </Button>
+            <Button
+              variant="default"
+              size="lg"
+              asChild={Boolean(nextSubmission)}
+              disabled={!nextSubmission}
+              className={cn(
+                "w-32 px-6 whitespace-nowrap",
+                !nextSubmission && "opacity-50",
+              )}
+            >
+              {nextSubmission ? (
+                <Link
+                  href={`/teacher/classroom/${classroomId}/assignment/${assignmentId}/review/${nextSubmission._id}?filter=${filterMode}`}
+                  className="flex items-center gap-2"
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </Link>
+              ) : (
+                <span className="flex items-center gap-2">
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </span>
+              )}
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant={filterMode === "all" ? "outline" : "default"}
+                  size="lg"
+                  className="gap-2"
+                >
+                  <Filter className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuItem
+                  onClick={() => setFilterMode("all")}
+                  className={cn(filterMode === "all" && "bg-muted")}
+                >
+                  All Submissions
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => setFilterMode("ungraded")}
+                  className={cn(filterMode === "ungraded" && "bg-muted")}
+                >
+                  Ungraded
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => setFilterMode("flagged")}
+                  className={cn(filterMode === "flagged" && "bg-muted")}
+                >
+                  Flagged
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+
+        <div className="mb-6 space-y-1">
+          <h1 className="text-3xl font-bold">Review Submission</h1>
+          <p className="text-muted-foreground text-sm">
+            {assignment.name} • {studentDisplayName}
+          </p>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Submission Details</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div className="flex justify-between gap-4">
+                  <span className="text-muted-foreground">Student</span>
+                  <span className="font-medium">{studentDisplayName}</span>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <span className="text-muted-foreground">Grade</span>
+                  <span className="font-medium">
+                    {submission.grade !== undefined
+                      ? `${submission.grade}%`
+                      : "Not graded"}
+                  </span>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <span className="text-muted-foreground">Workspace</span>
+                  <span className="font-mono text-xs">
+                    {submission.workspaceId ?? "Not linked"}
+                  </span>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <span className="text-muted-foreground">Published</span>
+                  <span className="font-medium">
+                    {submission.gradesReleased ? (
+                      <span className="text-accent-foreground inline-flex items-center gap-1">
+                        <CheckCircle2 className="h-3 w-3" />
+                        Yes
+                      </span>
+                    ) : (
+                      "No"
+                    )}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <div className="flex justify-between pr-6">
+                <CardHeader className="flex-1">
+                  <CardTitle>Replay</CardTitle>
+                  <CardDescription>
+                    Scrub through the workspace edit history for this
+                    submission.
+                  </CardDescription>
+                </CardHeader>
+                <div>
+                  <Button
+                    className={cn(
+                      "gap-2 font-medium text-white transition-all",
+                      {
+                        "bg-red-800 hover:bg-blue-500": submission.flagged,
+                        "bg-red-700 hover:bg-red-600": !submission.flagged,
+                      },
+                    )}
+                    onClick={() =>
+                      toggleSubmissionFlag({ submissionId: submission._id })
+                    }
+                  >
+                    <Flag className="h-4 w-4" />
+                    {submission.flagged
+                      ? "Unflag Submission"
+                      : "Flag Submission"}
+                  </Button>
+                </div>
+              </div>
+              <CardContent>
+                {submission.workspaceId ? (
+                  <TextReplayScrubberComponent
+                    workspaceId={submission.workspaceId}
+                  />
+                ) : (
+                  <p className="text-muted-foreground text-sm">
+                    No workspace is attached to this submission, so replay is
+                    unavailable.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Grading</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="review-grade">Grade</Label>
+                  <InputGroup>
+                    <InputGroupInput
+                      id="review-grade"
+                      value={displayGrade}
+                      onChange={(event) =>
+                        setNewGrade(sanitizeGradeInput(event.target.value))
+                      }
+                      placeholder="e.g. 95"
+                      type="text"
+                      inputMode="decimal"
+                    />
+                    <InputGroupAddon align="inline-end">
+                      <InputGroupText>%</InputGroupText>
+                    </InputGroupAddon>
+                  </InputGroup>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="review-feedback">Feedback</Label>
+                  <textarea
+                    id="review-feedback"
+                    rows={6}
+                    value={displayFeedback}
+                    onChange={(event) => setNewFeedback(event.target.value)}
+                    placeholder="Feedback for the student"
+                    className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[140px] w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                  />
+                </div>
+
+                <Button
+                  className="w-full"
+                  onClick={handleSave}
+                  disabled={isSaving}
+                >
+                  {isSaving ? "Saving..." : "Save Grade & Feedback"}
+                </Button>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Status</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                <div className="flex justify-between gap-4">
+                  <span className="text-muted-foreground">Grade</span>
+                  <span className="font-medium">
+                    {submission.grade !== undefined
+                      ? `${submission.grade}%`
+                      : "Not graded"}
+                  </span>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <span className="text-muted-foreground">Graded At</span>
+                  <span className="font-medium">
+                    {submission.gradedAt
+                      ? new Date(submission.gradedAt).toLocaleString()
+                      : "Not graded"}
+                  </span>
+                </div>
+                <Separator />
+                <p className="text-muted-foreground text-xs">
+                  Feedback and grade are saved independently, so you can update
+                  either field at any time.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
### TL;DR

Enhanced grade input validation and user experience for the teacher submission review page with input sanitization, negative grade prevention, and confirmation dialog for grades over 100.

### What changed?

- Added `sanitizeGradeInput` function to filter out non-numeric characters except digits and decimal points
- Changed grade input from `type="number"` to `type="text"` with `inputMode="decimal"` to prevent browser spinner controls
- Added validation to prevent negative grades with error toast
- Implemented confirmation dialog for grades above 100 with escape key support
- Refactored save logic into separate `saveReview` function for better code organization

### How to test?

1. Navigate to a submission review page as a teacher
2. Try entering invalid characters in the grade field - they should be automatically filtered out
3. Attempt to save a negative grade - should show error toast
4. Enter a grade above 100 and save - should show confirmation dialog
5. Test escape key functionality to close the confirmation dialog
6. Verify normal grade saving still works for valid grades (0-100)

### Why make this change?

Improves data integrity and user experience by preventing invalid grade entries, providing clear feedback for edge cases, and ensuring teachers can't accidentally submit problematic grades without confirmation. The input sanitization prevents common user errors while the validation catches logical issues before they reach the database.

closes #265