### PR TITLE
feat: open workspace in new tab

### DIFF
--- a/apps/nextjs/src/app/student/classroom/[id]/assignment/[assignmentId]/page.tsx
+++ b/apps/nextjs/src/app/student/classroom/[id]/assignment/[assignmentId]/page.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  startTransition,
-  use,
-  useActionState,
-  useEffect,
-  useState,
-} from "react";
+import { startTransition, use, useActionState, useState } from "react";
 import Link from "next/link";
 import { useMutation, useQuery } from "convex/react";
 import { ArrowLeft, Calendar, CheckCircle2, Clock } from "lucide-react";
@@ -49,17 +43,21 @@ function Content({
   const submitAssignment = useMutation(api.web.submission.submitAssignment);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitConfirmOpen, setIsSubmitConfirmOpen] = useState(false);
-
   const [workspaceUrl, launchAction, isLaunching] = useActionState(
-    () => launchWorkspace(assignmentId),
+    (_: unknown, id: Id<"assignments"> | null) => {
+      if (!id) {
+        return null;
+      }
+      return launchWorkspace(id);
+    },
     null as string | null,
   );
 
-  useEffect(() => {
-    if (workspaceUrl) {
-      window.location.assign(workspaceUrl);
-    }
-  }, [workspaceUrl]);
+  const handleLaunchWorkspace = () => {
+    startTransition(() => {
+      launchAction(assignmentId);
+    });
+  };
 
   if (assignment === undefined || submissionResult === undefined) {
     return (
@@ -121,7 +119,15 @@ function Content({
 
   return (
     <div className="container mx-auto p-6">
-      <WorkspaceLaunchingOverlay isLaunching={isLaunching} />
+      <WorkspaceLaunchingOverlay
+        isLaunching={isLaunching}
+        workspaceUrl={workspaceUrl}
+        onClose={() => {
+          startTransition(() => {
+            launchAction(null);
+          });
+        }}
+      />
       <div className="mb-4">
         <Link
           href={`/student/classroom/${classroomId}`}
@@ -253,9 +259,7 @@ function Content({
                   </Button>
                   <Button
                     className="w-full"
-                    onClick={() => {
-                      startTransition(launchAction);
-                    }}
+                    onClick={handleLaunchWorkspace}
                     disabled={isLaunching}
                   >
                     {isLaunching ? "Launching..." : "Launch Workspace"}

--- a/apps/nextjs/src/app/student/classroom/[id]/page.tsx
+++ b/apps/nextjs/src/app/student/classroom/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { startTransition, use, useActionState, useEffect } from "react";
+import { startTransition, use, useActionState } from "react";
 import Link from "next/link";
 import { useMutation, useQuery } from "convex/react";
 import { ArrowLeft, CheckCircle2 } from "lucide-react";
@@ -59,22 +59,35 @@ function AssignmentCard({
     },
   );
   const [workspaceUrl, launchAction, isLaunching] = useActionState(
-    () => launchWorkspace(assignment._id),
+    (_: unknown, assignmentId: string | null) => {
+      if (!assignmentId) {
+        return null;
+      }
+      return launchWorkspace(assignment._id);
+    },
     null as string | null,
   );
 
-  useEffect(() => {
-    if (workspaceUrl) {
-      window.location.assign(workspaceUrl);
-    }
-  }, [workspaceUrl]);
+  const handleLaunchWorkspace = () => {
+    startTransition(() => {
+      launchAction(assignment._id);
+    });
+  };
 
   const hasSubmission = submissionResult?.success === true;
   const dueDate = new Date(assignment.dueDate);
 
   return (
     <Card>
-      <WorkspaceLaunchingOverlay isLaunching={isLaunching} />
+      <WorkspaceLaunchingOverlay
+        isLaunching={isLaunching}
+        workspaceUrl={workspaceUrl}
+        onClose={() => {
+          startTransition(() => {
+            launchAction(null);
+          });
+        }}
+      />
       <CardHeader className="space-y-2">
         <div className="flex items-start justify-between gap-3">
           <div className="space-y-1">
@@ -94,9 +107,7 @@ function AssignmentCard({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => {
-              startTransition(launchAction);
-            }}
+            onClick={handleLaunchWorkspace}
             disabled={isLaunching}
           >
             {isLaunching ? "Launching..." : "Launch Workspace"}

--- a/apps/nextjs/src/components/workspace-launching-overlay.tsx
+++ b/apps/nextjs/src/components/workspace-launching-overlay.tsx
@@ -1,23 +1,66 @@
+import { CheckCircle2 } from "lucide-react";
+
+import { Button } from "@package/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@package/ui/dialog";
 import { Spinner } from "@package/ui/spinner";
 
 export function WorkspaceLaunchingOverlay({
   isLaunching,
+  workspaceUrl,
+  onClose,
 }: {
   isLaunching: boolean;
+  workspaceUrl: string | null;
+  onClose: () => void;
 }) {
-  if (!isLaunching) return null;
+  const isOpen = isLaunching || Boolean(workspaceUrl);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="bg-background flex flex-col items-center gap-4 rounded-lg border p-8 shadow-lg">
-        <Spinner className="size-8" />
-        <div className="text-center">
-          <p className="text-lg font-semibold">Launching workspace</p>
-          <p className="text-muted-foreground text-sm">
-            This should take around 30 seconds...
-          </p>
-        </div>
-      </div>
-    </div>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent showCloseButton={!isLaunching}>
+        {isLaunching ? (
+          <DialogHeader className="items-center">
+            <Spinner className="size-8" />
+            <DialogTitle>Launching workspace</DialogTitle>
+            <DialogDescription>
+              This should take around 30 seconds...
+            </DialogDescription>
+          </DialogHeader>
+        ) : (
+          <>
+            <DialogHeader className="items-center">
+              <CheckCircle2 className="size-8 text-green-500" />
+              <DialogTitle>Workspace ready</DialogTitle>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="outline" onClick={onClose}>
+                Close
+              </Button>
+              <Button asChild>
+                <a
+                  href={workspaceUrl ?? ""}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Open Workspace
+                </a>
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,6 +6,7 @@
     ".": "./src/index.ts",
     "./button": "./src/button.tsx",
     "./card": "./src/card.tsx",
+    "./dialog": "./src/dialog.tsx",
     "./dropdown-menu": "./src/dropdown-menu.tsx",
     "./field": "./src/field.tsx",
     "./form": "./src/form.tsx",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,7 +165,7 @@ importers:
         version: 0.552.0(react@19.2.0)
       next:
         specifier: 16.0.10
-        version: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: catalog:react19
         version: 19.2.0
@@ -323,7 +323,7 @@ importers:
         version: 0.552.0(react@19.2.0)
       next:
         specifier: 16.0.10
-        version: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: catalog:react19
         version: 19.2.0
@@ -11425,7 +11425,7 @@ snapshots:
       nanostores: 1.0.1
       zod: 4.1.12
     optionalDependencies:
-      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       vitest: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@22.18.12)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
@@ -12498,7 +12498,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.4
       lucide-react: 0.552.0(react@19.2.0)
-      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
@@ -12525,7 +12525,7 @@ snapshots:
       unist-util-visit: 5.0.0
       zod: 4.1.12
     optionalDependencies:
-      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       vite: 7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     transitivePeerDependencies:
@@ -12555,7 +12555,7 @@ snapshots:
       tailwind-merge: 3.3.1
     optionalDependencies:
       '@types/react': 19.2.4
-      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tailwindcss: 4.1.16
     transitivePeerDependencies:
       - '@mixedbread/sdk'
@@ -13887,7 +13887,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@16.0.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@next/env': 16.0.10
       '@swc/helpers': 0.5.15
@@ -13895,7 +13895,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.0)
+      styled-jsx: 5.1.6(react@19.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.0.10
       '@next/swc-darwin-x64': 16.0.10
@@ -15205,12 +15205,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.6
 
-  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.0):
+  styled-jsx@5.1.6(react@19.2.0):
     dependencies:
       client-only: 0.0.1
       react: 19.2.0
-    optionalDependencies:
-      '@babel/core': 7.28.5
 
   supports-color@10.2.2: {}
 


### PR DESCRIPTION
### TL;DR

Changed workspace URL navigation to open in new tabs instead of redirecting the current page

### What changed?

Replaced `window.location.assign(workspaceUrl)` with `window.open(workspaceUrl, "_blank")` in both the assignment detail page and classroom assignment card components. This changes the behavior from navigating away from the current page to opening workspace URLs in new browser tabs.

### How to test?

1. Navigate to a student classroom page with assignments
2. Click on an assignment that has a workspace URL
3. Verify that the workspace opens in a new tab instead of replacing the current page
4. Test both from the classroom list view and individual assignment detail view
5. Confirm the original page remains accessible in the previous tab

### Why make this change?

This improves user experience by preserving the student's navigation context. Students can now access their workspace while keeping the classroom interface available for reference, making it easier to switch between the assignment details and their work environment without losing their place in the application.