### PR TITLE
fix: update kubneretes to fetch extention from github

### DIFF
--- a/infra/coder-templates/kubernetes/main.tf
+++ b/infra/coder-templates/kubernetes/main.tf
@@ -134,9 +134,14 @@ resource "coder_agent" "main" {
     # Install the latest code-server.
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
 
-    # Install the leopard extension
-    curl -fL -o /tmp/latest.vsix http://noname.nolapse.tech/files/latest.vsix
-    /tmp/code-server/bin/code-server --install-extension /tmp/latest.vsix
+    # Get the latest extention from github and install it
+    VSIX_URL=$(curl -s https://api.github.com/repos/Beanie-Brick-Band/leopard/releases/tags/vscode-extension-latest \
+    | grep 'browser_download_url.*vsix' \
+    | cut -d '"' -f 4)
+
+    curl -L -o /tmp/extension.vsix "$VSIX_URL"
+
+    /tmp/code-server/bin/code-server --install-extension /tmp/extension.vsix
 
     # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &


### PR DESCRIPTION
### TL;DR

Updated the leopard extension installation to fetch the latest release from GitHub instead of using a hardcoded URL.

### What changed?

The code-server setup script now dynamically retrieves the latest leopard extension VSIX file from the GitHub releases API. Instead of downloading from a fixed URL at `http://noname.nolapse.tech/files/latest.vsix`, it queries the GitHub API for the `vscode-extension-latest` tag and extracts the browser download URL for the VSIX file.

### How to test?

1. Deploy a new Coder workspace using this template
2. Verify that code-server starts successfully
3. Check that the leopard extension is installed and functional in the code-server instance
4. Confirm the extension version matches the latest release from the Beanie-Brick-Band/leopard repository

### Why make this change?

This change improves reliability and maintainability by removing the dependency on a custom server endpoint and instead using GitHub's official releases API. This ensures the extension installation will continue working even if the previous hosting solution becomes unavailable, and automatically pulls the most recent version without manual intervention.