### PR TITLE
feat(backend): added publishGrades mutation

### DIFF
--- a/packages/backend/convex/web/submission.ts
+++ b/packages/backend/convex/web/submission.ts
@@ -15,7 +15,7 @@ const requireStudentRole = async (ctx: DatabaseCtx, userId: string) => {
   return role;
 };
 
-const checkGraderAccess = async (
+export const checkGraderAccess = async (
   uid: string,
   ctx: DatabaseCtx,
   assignmentId: Id<"assignments">,

--- a/packages/backend/convex/web/teacherAssignments.ts
+++ b/packages/backend/convex/web/teacherAssignments.ts
@@ -12,6 +12,7 @@ import {
 } from "../_generated/server";
 import { authComponent } from "../auth";
 import { getObjectKey } from "../helpers/storageKeys";
+import { checkGraderAccess } from "./submission";
 import { requireInstructorAccess } from "./teacher";
 import { getUserRole, requireAuth } from "./user";
 
@@ -402,6 +403,30 @@ export const provideSubmissionFeedback = mutation({
     });
 
     return submission._id;
+  },
+});
+
+export const publishGrades = mutation({
+  args: {
+    assignmentId: v.id("assignments"),
+  },
+  handler: async (ctx, args) => {
+    const user = await requireAuth(ctx);
+
+    await checkGraderAccess(user._id, ctx, args.assignmentId);
+
+    const submissions = await ctx.db
+      .query("submissions")
+      .withIndex("assignmentId_studentId", (q) =>
+        q.eq("assignmentId", args.assignmentId),
+      )
+      .collect();
+
+    await Promise.all(
+      submissions
+        .filter((s) => !s.gradesReleased)
+        .map((s) => ctx.db.patch(s._id, { gradesReleased: true })),
+    );
   },
 });
 


### PR DESCRIPTION
### TL;DR

Added a new `publishGrades` mutation that allows teachers to release grades for all submissions in an assignment.

### What changed?

Added the `publishGrades` mutation in `teacherAssignments.ts` that:
- Takes an `assignmentId` parameter
- Requires authentication and instructor access to the classroom
- Queries all submissions for the assignment
- Updates the `gradesReleased` field to `true` for submissions that haven't been released yet
- Returns the total number of submissions that were processed

### How to test?

1. Create an assignment with student submissions that have grades but `gradesReleased: false`
2. Call the `publishGrades` mutation with the assignment ID as a teacher
3. Verify that all submissions for that assignment now have `gradesReleased: true`
4. Confirm that the mutation returns the correct count of submissions
5. Test that non-instructors cannot call this mutation (should fail authorization)

### Why make this change?

This enables teachers to bulk-release grades for an entire assignment at once, rather than having to release grades individually for each submission. This improves the workflow for teachers who want to grade all submissions privately before making them visible to students simultaneously.