### PR TITLE
feat(web): publish status on teacher assignment submission view

### DIFF
--- a/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/review/[submissionId]/page.tsx
+++ b/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/review/[submissionId]/page.tsx
@@ -3,7 +3,7 @@
 import { use, useState } from "react";
 import Link from "next/link";
 import { useMutation, useQuery } from "convex/react";
-import { ArrowLeft, Flag } from "lucide-react";
+import { ArrowLeft, CheckCircle2, Flag } from "lucide-react";
 import { toast } from "sonner";
 
 import type { Id } from "@package/backend/convex/_generated/dataModel";
@@ -153,6 +153,19 @@ function ReviewContent({
                 <span className="text-muted-foreground">Workspace</span>
                 <span className="font-mono text-xs">
                   {submission.workspaceId ?? "Not linked"}
+                </span>
+              </div>
+              <div className="flex justify-between gap-4">
+                <span className="text-muted-foreground">Published</span>
+                <span className="font-medium">
+                  {submission.gradesReleased ? (
+                    <span className="text-accent-foreground inline-flex items-center gap-1">
+                      <CheckCircle2 className="h-3 w-3" />
+                      Yes
+                    </span>
+                  ) : (
+                    "No"
+                  )}
                 </span>
               </div>
             </CardContent>


### PR DESCRIPTION
### TL;DR

Added a "Published" status indicator to the submission review page that shows whether grades have been released to students.

### What changed?

Added a new field in the submission details card that displays the publication status of grades. When `gradesReleased` is true, it shows "Yes" with a green checkmark icon. When false, it displays "No" in plain text.

### How to test?

1. Navigate to a teacher's submission review page
2. Check the submission details card for the new "Published" field
3. Verify that submissions with released grades show a green "Yes" with checkmark icon
4. Verify that submissions without released grades show "No"

### Why make this change?

This provides teachers with immediate visibility into whether students can see their grades for a particular submission, helping them track the publication status of their grading work.