### PR TITLE
feat(web): show student assignment grade when grades are released

### DIFF
--- a/apps/nextjs/src/app/student/classroom/[id]/assignment/[assignmentId]/page.tsx
+++ b/apps/nextjs/src/app/student/classroom/[id]/assignment/[assignmentId]/page.tsx
@@ -166,10 +166,17 @@ function Content({
                 <Clock className="h-4 w-4" />
                 {new Date(assignment.dueDate).toLocaleTimeString()}
               </span>
-              {hasSubmission ? (
+              {submissionResult.success &&
+              !submissionResult.submission?.gradesReleased ? (
                 <span className="inline-flex items-center gap-1 text-green-600 dark:text-green-400">
-                  <CheckCircle2 className="h-4 w-4" />
+                  <CheckCircle2 className="h-3 w-3" />
                   Submitted
+                </span>
+              ) : submissionResult.success &&
+                submissionResult.submission?.gradesReleased ? (
+                <span className="inline-flex items-center gap-1 text-green-600 dark:text-green-400">
+                  <CheckCircle2 className="h-3 w-3" />
+                  Graded
                 </span>
               ) : null}
             </div>
@@ -209,7 +216,7 @@ function Content({
               </CardHeader>
               <CardContent className="space-y-3">
                 <p className="text-4xl font-bold text-green-600 dark:text-green-400">
-                  {grade}
+                  {grade}%
                 </p>
                 {feedback ? (
                   <div>

--- a/apps/nextjs/src/app/student/classroom/[id]/page.tsx
+++ b/apps/nextjs/src/app/student/classroom/[id]/page.tsx
@@ -74,7 +74,6 @@ function AssignmentCard({
     });
   };
 
-  const hasSubmission = submissionResult?.success === true;
   const dueDate = new Date(assignment.dueDate);
 
   return (
@@ -94,10 +93,17 @@ function AssignmentCard({
             <CardTitle className="text-lg">{assignment.name}</CardTitle>
             <CardDescription>Due {dueDate.toLocaleString()}</CardDescription>
           </div>
-          {hasSubmission ? (
+          {submissionResult?.success &&
+          !submissionResult.submission?.gradesReleased ? (
             <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800">
               <CheckCircle2 className="h-3 w-3" />
               Submitted
+            </span>
+          ) : submissionResult?.success &&
+            submissionResult.submission?.gradesReleased ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800">
+              <CheckCircle2 className="h-3 w-3" />
+              Graded: {submissionResult.submission.grade}%
             </span>
           ) : null}
         </div>


### PR DESCRIPTION
### TL;DR

Enhanced assignment cards to display grades when they are released, replacing the generic "Submitted" status.

### What changed?

Modified the AssignmentCard component to show different status badges based on submission state:

- Displays "Submitted" for assignments that have been submitted but grades are not yet released
- Displays "Graded: [grade]" for assignments where grades have been released
- Removed the `hasSubmission` variable and replaced it with more specific conditional logic

![image.png](https://app.graphite.com/user-attachments/assets/24834226-a4a0-4f30-8012-b03f1d779ded.png)

![image.png](https://app.graphite.com/user-attachments/assets/58f864ec-d3b3-4abb-afaf-ecf36044adc9.png)



### How to test?

1. Navigate to a student classroom page with assignments
2. Verify that submitted assignments without released grades show "Submitted" status
3. Verify that submitted assignments with released grades show "Graded: [grade]" status
4. Confirm that unsubmitted assignments show no status badge

### Why make this change?

This provides students with more meaningful feedback about their assignment status, allowing them to see their actual grades once they've been released by the instructor rather than just knowing their submission was received.