### PR TITLE
feat(backend): add hideGrades mutation for teacher assignments

### DIFF
--- a/packages/backend/convex/web/teacherAssignments.ts
+++ b/packages/backend/convex/web/teacherAssignments.ts
@@ -406,6 +406,30 @@ export const provideSubmissionFeedback = mutation({
   },
 });
 
+export const hideGrades = mutation({
+  args: {
+    assignmentId: v.id("assignments"),
+  },
+  handler: async (ctx, args) => {
+    const user = await requireAuth(ctx);
+
+    await checkGraderAccess(user._id, ctx, args.assignmentId);
+
+    const submissions = await ctx.db
+      .query("submissions")
+      .withIndex("assignmentId_studentId", (q) =>
+        q.eq("assignmentId", args.assignmentId),
+      )
+      .collect();
+
+    await Promise.all(
+      submissions
+        .filter((s) => s.gradesReleased)
+        .map((s) => ctx.db.patch(s._id, { gradesReleased: false })),
+    );
+  },
+});
+
 export const publishGrades = mutation({
   args: {
     assignmentId: v.id("assignments"),


### PR DESCRIPTION
### TL;DR

Added a new `hideGrades` mutation to allow teachers to hide previously released grades for an assignment.

### What changed?

Added the `hideGrades` mutation in `teacherAssignments.ts` that:
- Takes an `assignmentId` parameter
- Requires authentication and grader access verification
- Queries all submissions for the assignment
- Sets `gradesReleased` to `false` for any submissions that currently have grades released

### How to test?

1. Create an assignment with submissions that have grades released (`gradesReleased: true`)
2. Call the `hideGrades` mutation with the assignment ID as a teacher/grader
3. Verify that all submissions for that assignment now have `gradesReleased: false`
4. Confirm that students can no longer see their grades for the assignment

### Why make this change?

This provides teachers with the ability to retract grades after they've been published, which is useful when corrections need to be made or when grades were released prematurely.