### PR TITLE
fix(web): tiptap-shiki dark theme

### DIFF
--- a/apps/nextjs/src/app/styles.css
+++ b/apps/nextjs/src/app/styles.css
@@ -221,3 +221,11 @@
     padding: 0;
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  .tiptap .shiki,
+  .tiptap .shiki span {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
+  }
+}

--- a/apps/nextjs/src/components/app-data-grid.tsx
+++ b/apps/nextjs/src/components/app-data-grid.tsx
@@ -2,9 +2,9 @@
 
 import type { ColDef, Module } from "ag-grid-community";
 import type { CSSProperties } from "react";
+import { useRouter } from "next/navigation";
 import { AllCommunityModule } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
-import { useRouter } from "next/navigation";
 
 import { cn } from "@package/ui";
 import { useTheme } from "@package/ui/theme";

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -11,7 +11,6 @@
 import type * as api_coder from "../api/coder.js";
 import type * as api_extension from "../api/extension.js";
 import type * as auth from "../auth.js";
-import type * as helpers_coder from "../helpers/coder.js";
 import type * as helpers_minio from "../helpers/minio.js";
 import type * as helpers_roles from "../helpers/roles.js";
 import type * as helpers_storageKeys from "../helpers/storageKeys.js";
@@ -37,7 +36,6 @@ declare const fullApi: ApiFromModules<{
   "api/coder": typeof api_coder;
   "api/extension": typeof api_extension;
   auth: typeof auth;
-  "helpers/coder": typeof helpers_coder;
   "helpers/minio": typeof helpers_minio;
   "helpers/roles": typeof helpers_roles;
   "helpers/storageKeys": typeof helpers_storageKeys;


### PR DESCRIPTION
Fixed dark theme syntax highlighting as per https://github.com/timomeh/tiptap-extension-code-block-shiki

![image.png](https://app.graphite.com/user-attachments/assets/c79e5082-b0dd-48fa-bbb0-e9c6ade951f5.png)

