### PR TITLE
fix(backend): prevent unreleased assignments from being viewed by students

### DIFF
--- a/packages/backend/convex/web/teacherAssignments.ts
+++ b/packages/backend/convex/web/teacherAssignments.ts
@@ -130,9 +130,14 @@ export const getAssignmentsByClassroom = query({
       user._id,
     );
 
+    const role = await getUserRole(ctx, user._id);
+
     const assignments = (
       await Promise.all(classroom.assignments.map((id) => ctx.db.get(id)))
-    ).filter((a): a is NonNullable<typeof a> => a !== null);
+    ).filter(
+      (a): a is NonNullable<typeof a> =>
+        a !== null && (role !== "student" || a.releaseDate <= Date.now()),
+    );
 
     return assignments;
   },

--- a/packages/backend/tests/web_api/web.teacherAssignments.test.ts
+++ b/packages/backend/tests/web_api/web.teacherAssignments.test.ts
@@ -96,6 +96,69 @@ describe("web/teacherAssignments", () => {
         }),
       ).rejects.toThrow("Not authorized to view classroom assignments");
     });
+
+    it("allows students to see assignment with releaseDate in the past", async () => {
+      const t = makeTestClient();
+      const classroomId = await seedClassroom(t, { ownerId: "teacher_1" });
+      const assignmentId = await seedAssignment(t, classroomId, {
+        releaseDate: Date.now() - 1000,
+      });
+      await seedEnrollment(t, classroomId, "student_1");
+
+      safeGetAuthUser.mockResolvedValue({
+        _id: "student_1",
+        email: "s@example.com",
+      });
+      const res = await t.query(
+        api.web.teacherAssignments.getAssignmentsByClassroom,
+        {
+          classroomId,
+        },
+      );
+      expect(res.map((a) => a._id)).toEqual([assignmentId]);
+    });
+
+    it("dissallows students to see assignment with releaseDate in the future", async () => {
+      const t = makeTestClient();
+      const classroomId = await seedClassroom(t, { ownerId: "teacher_1" });
+      await seedAssignment(t, classroomId, {
+        releaseDate: Date.now() + 1000000,
+      });
+      await seedEnrollment(t, classroomId, "student_1");
+
+      safeGetAuthUser.mockResolvedValue({
+        _id: "student_1",
+        email: "s@example.com",
+      });
+      const res = await t.query(
+        api.web.teacherAssignments.getAssignmentsByClassroom,
+        {
+          classroomId,
+        },
+      );
+      expect(res.length).toBe(0);
+    });
+
+    it("allows teachers to see all assignments regardless of releaseDate", async () => {
+      const t = makeTestClient();
+      await seedUserRole(t, "teacher_1", "teacher");
+      const classroomId = await seedClassroom(t, { ownerId: "teacher_1" });
+      const assignmentId = await seedAssignment(t, classroomId, {
+        releaseDate: Date.now() + 1000000,
+      });
+
+      safeGetAuthUser.mockResolvedValue({
+        _id: "teacher_1",
+        email: "t@example.com",
+      });
+      const res = await t.query(
+        api.web.teacherAssignments.getAssignmentsByClassroom,
+        {
+          classroomId,
+        },
+      );
+      expect(res.map((a) => a._id)).toEqual([assignmentId]);
+    });
   });
 
   describe("createAssignment / updateAssignment", () => {


### PR DESCRIPTION
### TL;DR

Added release date filtering to teacher assignment queries to only return assignments that have been released.

### What changed?

Modified the `getAssignmentsByClassroom` query to filter out assignments where the `releaseDate` is in the future. The filter now checks both that the assignment exists (`a !== null`) and that the current time has passed the assignment's release date (`a.releaseDate <= Date.now()`).

### How to test?

1. Create assignments with future release dates in a classroom
2. Query assignments for that classroom using `getAssignmentsByClassroom`
3. Verify that only assignments with release dates in the past or present are returned
4. Test with assignments that have no release date or past release dates to ensure they still appear

### Why make this change?

This prevents teachers from seeing assignments that haven't been released yet, ensuring proper timing control over when assignments become visible in the teacher interface.

resolves #249