### PR TITLE
feat: admin role page

### DIFF
--- a/apps/nextjs/src/app/admin/page.tsx
+++ b/apps/nextjs/src/app/admin/page.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+
+import { api } from "@package/backend/convex/_generated/api";
+import { Button } from "@package/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@package/ui/card";
+
+import AdminUserManagement from "~/components/admin-user-management";
+import { fetchAuthQuery, isAuthenticated } from "~/lib/auth-server";
+
+export default async function AdminPage() {
+  const authenticated = await isAuthenticated();
+
+  if (!authenticated) {
+    return (
+      <main className="container mx-auto max-w-xl p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Sign In Required</CardTitle>
+            <CardDescription>
+              Sign in to open the admin user management page.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild>
+              <Link href="/auth/sign-in">Sign In</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
+  const role = await fetchAuthQuery(api.web.user.getCurrentUserRole, {});
+
+  if (role !== "admin") {
+    return (
+      <main className="container mx-auto max-w-xl p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Admin Access Required</CardTitle>
+            <CardDescription>
+              Only admins can manage user roles.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild>
+              <Link href="/app">Back to App</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
+  return (
+    <main>
+      <AdminUserManagement />
+    </main>
+  );
+}

--- a/apps/nextjs/src/app/app/page.tsx
+++ b/apps/nextjs/src/app/app/page.tsx
@@ -19,12 +19,9 @@ import {
 } from "~/lib/auth-server";
 
 async function getDashboardRole() {
-  try {
-    await fetchAuthQuery(api.web.teacher.getMyClassrooms, {});
-    return "teacher" as const;
-  } catch {
-    return "student" as const;
-  }
+  return (
+    (await fetchAuthQuery(api.web.user.getCurrentUserRole, {})) ?? "student"
+  );
 }
 
 export default async function Page() {
@@ -50,10 +47,15 @@ export default async function Page() {
 
   await fetchAuthMutation(api.web.user.ensureCurrentUserRole, {});
   const role = await getDashboardRole();
+  const isInstructor = role === "teacher" || role === "admin";
 
   return (
     <main>
-      {role === "teacher" ? <TeacherDashboard /> : <StudentDashboard />}
+      {isInstructor ? (
+        <TeacherDashboard isAdmin={role === "admin"} />
+      ) : (
+        <StudentDashboard />
+      )}
     </main>
   );
 }

--- a/apps/nextjs/src/components/admin-user-management.tsx
+++ b/apps/nextjs/src/components/admin-user-management.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useDeferredValue, useState } from "react";
+import Link from "next/link";
+import { useMutation, useQuery } from "convex/react";
+import { toast } from "sonner";
+
+import { api } from "@package/backend/convex/_generated/api";
+import { Button } from "@package/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@package/ui/card";
+import { Input } from "@package/ui/input";
+import { Label } from "@package/ui/label";
+import { Spinner } from "@package/ui/spinner";
+
+type UserRole = "admin" | "student" | "teacher";
+
+const roleLabels: Record<UserRole, string> = {
+  admin: "Admin",
+  student: "Student",
+  teacher: "Teacher",
+};
+
+function roleBadgeClassName(role: UserRole) {
+  switch (role) {
+    case "admin":
+      return "bg-orange-100 text-orange-950 dark:bg-orange-500/20 dark:text-orange-100";
+    case "teacher":
+      return "bg-blue-100 text-blue-950 dark:bg-blue-500/20 dark:text-blue-100";
+    case "student":
+      return "bg-muted text-muted-foreground";
+  }
+}
+
+export default function AdminUserManagement() {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [pendingChange, setPendingChange] = useState<{
+    role: UserRole;
+    userId: string;
+  } | null>(null);
+  const deferredSearchTerm = useDeferredValue(searchTerm.trim());
+  const users = useQuery(api.web.user.searchUsers, {
+    searchTerm: deferredSearchTerm,
+  });
+  const updateUserRole = useMutation(api.web.user.updateUserRole);
+
+  const handleRoleChange = async (
+    user: {
+      displayName: string;
+      role: UserRole;
+      userId: string;
+    },
+    role: UserRole,
+  ) => {
+    setPendingChange({ role, userId: user.userId });
+
+    try {
+      await updateUserRole({
+        role,
+        userId: user.userId,
+      });
+      toast.success(
+        `${user.displayName} is now a ${roleLabels[role].toLowerCase()}`,
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to update user role",
+      );
+    } finally {
+      setPendingChange(null);
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-5xl space-y-6 p-6">
+      <div className="space-y-2">
+        <Link href="/app" className="text-muted-foreground text-sm underline">
+          Back to App
+        </Link>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-3xl font-bold">Admin User Roles</h1>
+            <p className="text-muted-foreground text-sm">
+              Search Leopard users and update who can teach or administer the
+              app.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Search Users</CardTitle>
+          <CardDescription>
+            Search by name, email, username, role, or internal user ID.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Label htmlFor="user-search">Find a user</Label>
+          <Input
+            id="user-search"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="alice@example.com"
+          />
+        </CardContent>
+      </Card>
+
+      {users === undefined ? (
+        <div className="flex min-h-[280px] items-center justify-center">
+          <Spinner />
+        </div>
+      ) : users.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No Users Found</CardTitle>
+            <CardDescription>
+              Try a different search term or wait for more users to sign in.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {users.map((user) => (
+            <Card key={user.userId}>
+              <CardContent className="flex flex-col gap-4 py-6 md:flex-row md:items-center md:justify-between">
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="text-lg font-semibold">
+                      {user.displayName}
+                    </h2>
+                    {user.isCurrentUser ? (
+                      <span className="bg-primary/10 text-primary rounded-full px-2 py-0.5 text-xs font-medium">
+                        You
+                      </span>
+                    ) : null}
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${roleBadgeClassName(
+                        user.role,
+                      )}`}
+                    >
+                      {roleLabels[user.role]}
+                    </span>
+                  </div>
+                  <div className="text-muted-foreground space-y-1 text-sm">
+                    {user.email ? <p>{user.email}</p> : null}
+                    {user.username || user.displayUsername ? (
+                      <p>@{user.displayUsername ?? user.username}</p>
+                    ) : null}
+                    <p className="font-mono text-xs">{user.userId}</p>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  {(["student", "teacher", "admin"] as const).map((role) => {
+                    const isPending =
+                      pendingChange?.userId === user.userId &&
+                      pendingChange.role === role;
+                    const isDisabled =
+                      isPending ||
+                      user.role === role ||
+                      (user.isCurrentUser && role !== "admin");
+
+                    return (
+                      <Button
+                        key={role}
+                        size="sm"
+                        variant={user.role === role ? "default" : "outline"}
+                        disabled={isDisabled}
+                        onClick={() => handleRoleChange(user, role)}
+                      >
+                        {isPending ? "Saving..." : roleLabels[role]}
+                      </Button>
+                    );
+                  })}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/nextjs/src/components/header.tsx
+++ b/apps/nextjs/src/components/header.tsx
@@ -30,7 +30,8 @@ function getRole(pathname: string) {
   if (
     firstSegment === "teacher" ||
     firstSegment === "student" ||
-    firstSegment === "app"
+    firstSegment === "app" ||
+    firstSegment === "admin"
   ) {
     return firstSegment;
   }

--- a/apps/nextjs/src/components/teacher-dashboard.tsx
+++ b/apps/nextjs/src/components/teacher-dashboard.tsx
@@ -14,7 +14,11 @@ import {
 } from "@package/ui/card";
 import { Spinner } from "@package/ui/spinner";
 
-export default function TeacherDashboard() {
+export default function TeacherDashboard({
+  isAdmin = false,
+}: {
+  isAdmin?: boolean;
+}) {
   const classrooms = useQuery(api.web.teacher.getMyClassrooms);
 
   if (classrooms === undefined) {
@@ -31,12 +35,21 @@ export default function TeacherDashboard() {
         <div>
           <h1 className="text-3xl font-bold">Teacher Dashboard</h1>
           <p className="text-muted-foreground text-sm">
-            Manage classrooms and assignments
+            {isAdmin
+              ? "Manage classrooms, assignments, and user access"
+              : "Manage classrooms and assignments"}
           </p>
         </div>
-        <Button asChild>
-          <Link href="/teacher/classroom/new">Create Classroom</Link>
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          {isAdmin ? (
+            <Button asChild variant="outline">
+              <Link href="/admin">Manage Users</Link>
+            </Button>
+          ) : null}
+          <Button asChild>
+            <Link href="/teacher/classroom/new">Create Classroom</Link>
+          </Button>
+        </div>
       </div>
 
       {classrooms.length === 0 ? (

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -11,7 +11,6 @@
 import type * as api_coder from "../api/coder.js";
 import type * as api_extension from "../api/extension.js";
 import type * as auth from "../auth.js";
-import type * as helpers_coder from "../helpers/coder.js";
 import type * as helpers_minio from "../helpers/minio.js";
 import type * as helpers_roles from "../helpers/roles.js";
 import type * as helpers_storageKeys from "../helpers/storageKeys.js";
@@ -39,7 +38,6 @@ declare const fullApi: ApiFromModules<{
   "api/coder": typeof api_coder;
   "api/extension": typeof api_extension;
   auth: typeof auth;
-  "helpers/coder": typeof helpers_coder;
   "helpers/minio": typeof helpers_minio;
   "helpers/roles": typeof helpers_roles;
   "helpers/storageKeys": typeof helpers_storageKeys;

--- a/packages/backend/convex/web/user.ts
+++ b/packages/backend/convex/web/user.ts
@@ -1,20 +1,23 @@
-import { mutation, MutationCtx, QueryCtx } from "../_generated/server";
+import { v } from "convex/values";
+
+import type { UserRole } from "../helpers/roles";
+import { mutation, MutationCtx, query, QueryCtx } from "../_generated/server";
 import { authComponent } from "../auth";
+import { getUserRole as getStoredUserRole } from "../helpers/roles";
 
-type UserRole = "admin" | "student" | "teacher";
 type DbCtx = QueryCtx | MutationCtx;
+const DEFAULT_ROLE: UserRole = "student";
+const userRoleValidator = v.union(
+  v.literal("admin"),
+  v.literal("student"),
+  v.literal("teacher"),
+);
 
-export async function getUserRole(ctx: DbCtx, userId: string): Promise<UserRole> {
-  const user = await ctx.db
-    .query("users")
-    .withIndex("uid", (q) => q.eq("uid", userId))
-    .first();
-
-  if (!user) {
-    return "student";
-  }
-
-  return user.role;
+export async function getUserRole(
+  ctx: DbCtx,
+  userId: string,
+): Promise<UserRole> {
+  return getStoredUserRole(ctx, userId);
 }
 
 export async function requireAuth(ctx: DbCtx) {
@@ -30,6 +33,44 @@ export async function requireTeacherOrAdmin(ctx: DbCtx, userId: string) {
   if (role !== "teacher" && role !== "admin") {
     throw new Error("Only teachers can access this endpoint");
   }
+}
+
+export async function requireAdmin(ctx: DbCtx, userId: string) {
+  const role = await getUserRole(ctx, userId);
+  if (role !== "admin") {
+    throw new Error("Only admins can access this endpoint");
+  }
+}
+
+function normalizeText(value: string | null | undefined) {
+  return value?.trim() || null;
+}
+
+function matchesSearch(
+  searchTerm: string,
+  values: Array<string | null | undefined>,
+) {
+  if (!searchTerm) {
+    return true;
+  }
+
+  return values.some((value) => value?.toLowerCase().includes(searchTerm));
+}
+
+function getDisplayName(user: {
+  name: string | null;
+  displayUsername: string | null;
+  username: string | null;
+  email: string | null;
+  userId: string;
+}) {
+  return (
+    user.name ??
+    user.displayUsername ??
+    user.username ??
+    user.email ??
+    user.userId
+  );
 }
 
 export const ensureCurrentUserRole = mutation({
@@ -48,9 +89,120 @@ export const ensureCurrentUserRole = mutation({
 
     await ctx.db.insert("users", {
       uid: authUser._id,
-      role: "student",
+      role: DEFAULT_ROLE,
     });
 
-    return "student" as const;
+    return DEFAULT_ROLE;
+  },
+});
+
+export const getCurrentUserRole = query({
+  args: {},
+  handler: async (ctx) => {
+    const authUser = await authComponent.safeGetAuthUser(ctx);
+    if (!authUser) {
+      return null;
+    }
+
+    return getUserRole(ctx, authUser._id);
+  },
+});
+
+export const searchUsers = query({
+  args: {
+    searchTerm: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const authUser = await requireAuth(ctx);
+    await requireAdmin(ctx, authUser._id);
+
+    const normalizedSearch = args.searchTerm?.trim().toLowerCase() ?? "";
+    const users = await ctx.db.query("users").collect();
+
+    const enrichedUsers = await Promise.all(
+      users.map(async (user) => {
+        const authProfile = await authComponent.getAnyUserById(ctx, user.uid);
+        const name = normalizeText(authProfile?.name);
+        const email = normalizeText(authProfile?.email);
+        const username = normalizeText(authProfile?.username);
+        const displayUsername = normalizeText(authProfile?.displayUsername);
+
+        return {
+          displayName: getDisplayName({
+            name,
+            displayUsername,
+            username,
+            email,
+            userId: user.uid,
+          }),
+          displayUsername,
+          email,
+          isCurrentUser: user.uid === authUser._id,
+          name,
+          role: user.role,
+          userId: user.uid,
+          username,
+        };
+      }),
+    );
+
+    return enrichedUsers
+      .filter((user) =>
+        matchesSearch(normalizedSearch, [
+          user.displayName,
+          user.displayUsername,
+          user.email,
+          user.name,
+          user.role,
+          user.userId,
+          user.username,
+        ]),
+      )
+      .sort((left, right) => {
+        return (
+          left.displayName.localeCompare(right.displayName) ||
+          left.userId.localeCompare(right.userId)
+        );
+      })
+      .slice(0, 50);
+  },
+});
+
+export const updateUserRole = mutation({
+  args: {
+    role: userRoleValidator,
+    userId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const authUser = await requireAuth(ctx);
+    await requireAdmin(ctx, authUser._id);
+
+    if (args.userId === authUser._id && args.role !== "admin") {
+      throw new Error("Admins cannot remove their own admin access");
+    }
+
+    const targetUser = await authComponent.getAnyUserById(ctx, args.userId);
+    if (!targetUser) {
+      throw new Error("User not found");
+    }
+
+    const existingUser = await ctx.db
+      .query("users")
+      .withIndex("uid", (q) => q.eq("uid", args.userId))
+      .first();
+
+    if (existingUser) {
+      await ctx.db.patch(existingUser._id, {
+        role: args.role,
+      });
+      return args.role;
+    }
+
+    await ctx.db.insert("users", {
+      uid: args.userId,
+      role: args.role,
+    });
+
+    return args.role;
   },
 });

--- a/packages/backend/tests/web_api/web.user.test.ts
+++ b/packages/backend/tests/web_api/web.user.test.ts
@@ -1,0 +1,164 @@
+import { convexTest } from "convex-test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "../../convex/_generated/api";
+import * as apiModule from "../../convex/_generated/api";
+import { MutationCtx } from "../../convex/_generated/server";
+import schema from "../../convex/schema";
+import { seedUserRole } from "../helpers/seed";
+
+const authMocks = vi.hoisted(() => ({
+  getAnyUserById: vi.fn(),
+  safeGetAuthUser: vi.fn(),
+}));
+vi.mock("../../convex/auth", () => ({
+  authComponent: {
+    getAnyUserById: authMocks.getAnyUserById,
+    safeGetAuthUser: authMocks.safeGetAuthUser,
+  },
+}));
+
+const getAnyUserById = authMocks.getAnyUserById;
+const safeGetAuthUser = authMocks.safeGetAuthUser;
+
+function makeTestClient() {
+  const modules: Record<string, () => Promise<unknown>> = {
+    "convex/_generated/api.ts": () => Promise.resolve(apiModule),
+    "convex/web/user.ts": () => import("../../convex/web/user"),
+  };
+
+  return convexTest(schema, modules);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("web/user", () => {
+  describe("getCurrentUserRole", () => {
+    it("defaults to student when the authenticated user has no saved role", async () => {
+      const t = makeTestClient();
+      safeGetAuthUser.mockResolvedValue({
+        _id: "student_1",
+        email: "student@example.com",
+      });
+
+      await expect(t.query(api.web.user.getCurrentUserRole, {})).resolves.toBe(
+        "student",
+      );
+    });
+  });
+
+  describe("searchUsers", () => {
+    it("denies non-admins", async () => {
+      const t = makeTestClient();
+      await seedUserRole(t, "teacher_1", "teacher");
+      safeGetAuthUser.mockResolvedValue({
+        _id: "teacher_1",
+        email: "teacher@example.com",
+      });
+
+      await expect(
+        t.query(api.web.user.searchUsers, { searchTerm: "teach" }),
+      ).rejects.toThrow("Only admins can access this endpoint");
+    });
+
+    it("returns enriched matches for admins", async () => {
+      const t = makeTestClient();
+      await seedUserRole(t, "admin_1", "admin");
+      await seedUserRole(t, "teacher_1", "teacher");
+      await seedUserRole(t, "student_1", "student");
+
+      safeGetAuthUser.mockResolvedValue({
+        _id: "admin_1",
+        email: "admin@example.com",
+      });
+      getAnyUserById.mockImplementation(async (_ctx, id: string) => {
+        if (id === "admin_1") {
+          return {
+            email: "admin@example.com",
+            name: "Admin Example",
+          };
+        }
+
+        if (id === "teacher_1") {
+          return {
+            displayUsername: "teach_handle",
+            email: "teacher@example.com",
+            name: "Teacher Example",
+            username: "teacher-user",
+          };
+        }
+
+        if (id === "student_1") {
+          return {
+            email: "student@example.com",
+            name: "Student Example",
+          };
+        }
+
+        return null;
+      });
+
+      const results = await t.query(api.web.user.searchUsers, {
+        searchTerm: "teach",
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        displayName: "Teacher Example",
+        email: "teacher@example.com",
+        role: "teacher",
+        userId: "teacher_1",
+      });
+    });
+  });
+
+  describe("updateUserRole", () => {
+    it("updates an existing user role", async () => {
+      const t = makeTestClient();
+      await seedUserRole(t, "admin_1", "admin");
+      await seedUserRole(t, "student_1", "student");
+
+      safeGetAuthUser.mockResolvedValue({
+        _id: "admin_1",
+        email: "admin@example.com",
+      });
+      getAnyUserById.mockResolvedValue({
+        email: "student@example.com",
+        name: "Student Example",
+      });
+
+      await t.mutation(api.web.user.updateUserRole, {
+        role: "teacher",
+        userId: "student_1",
+      });
+
+      const updatedUser = await t.run(async (ctx: MutationCtx) => {
+        return ctx.db
+          .query("users")
+          .withIndex("uid", (q) => q.eq("uid", "student_1"))
+          .first();
+      });
+
+      expect(updatedUser?.role).toBe("teacher");
+    });
+
+    it("prevents admins from removing their own admin access", async () => {
+      const t = makeTestClient();
+      await seedUserRole(t, "admin_1", "admin");
+
+      safeGetAuthUser.mockResolvedValue({
+        _id: "admin_1",
+        email: "admin@example.com",
+      });
+
+      await expect(
+        t.mutation(api.web.user.updateUserRole, {
+          role: "teacher",
+          userId: "admin_1",
+        }),
+      ).rejects.toThrow("Admins cannot remove their own admin access");
+    });
+  });
+});


### PR DESCRIPTION
### TL;DR

Added admin user management functionality with role-based access control and a dedicated admin interface for managing user roles.

### What changed?

- Created `/admin` page with authentication and role-based access control that only allows admin users
- Added `AdminUserManagement` component with user search functionality and role assignment interface
- Enhanced `TeacherDashboard` to show admin-specific features and "Manage Users" button for admin users
- Updated role detection logic in the main app to use `getCurrentUserRole` API and treat both teachers and admins as instructors
- Added new backend queries and mutations:
  - `getCurrentUserRole` - gets the current user's role
  - `searchUsers` - searches and returns enriched user data (admin-only)
  - `updateUserRole` - updates user roles with validation (admin-only)
- Added role validation preventing admins from removing their own admin access
- Updated header component to recognize `/admin` route

### How to test?

1. Sign in as an admin user and navigate to `/admin` to access user management
2. Search for users by name, email, username, or role
3. Try updating user roles using the role buttons
4. Verify non-admin users cannot access the admin page
5. Test that admins cannot remove their own admin privileges
6. Check that the "Manage Users" button appears in the teacher dashboard for admin users

### Why make this change?

This enables proper user role management within the application, allowing administrators to promote users to teachers or other admins without requiring direct database access. The role-based access control ensures only authorized users can modify permissions, while the search functionality makes it easy to find and manage users at scale.