### PR TITLE
feat(web): making replay start at end

### DIFF
--- a/apps/nextjs/src/components/scrubber.tsx
+++ b/apps/nextjs/src/components/scrubber.tsx
@@ -84,7 +84,7 @@ export const TextReplayScrubberComponent: React.FC<TextReplayScrubberProps> = ({
     isScrubbing?: boolean;
     stickingTo?: number | null;
   }>({
-    value: frozenReplay ? 100 : 0,
+    value: 100,
     state: "None",
     isScrubbing: false,
     stickingTo: null,


### PR DESCRIPTION
### TL;DR

Set the scrubber value to always initialize at 100 instead of conditionally based on frozenReplay state

### What changed?

The TextReplayScrubberComponent now initializes the scrubber value to 100 in all cases, removing the conditional logic that previously set it to 100 when `frozenReplay` was true and 0 when false.

### How to test?

1. Load a replay in the application
2. Verify the scrubber starts at position 100 regardless of the replay's frozen state
3. Test both frozen and non-frozen replays to ensure consistent behavior

### Why make this change?

This change ensures consistent scrubber initialization behavior by removing the dependency on the `frozenReplay` state, which may have been causing inconsistent user experience when loading different types of replays.