### PR TITLE
fix: ensure coder user accounts are always activated before use

### DIFF
--- a/packages/backend/convex/helpers/coder.ts
+++ b/packages/backend/convex/helpers/coder.ts
@@ -1,4 +1,5 @@
 import {
+  activateUserAccount,
   createWorkspaceBuild,
   getWorkspaceMetadataByUserAndWorkspaceName,
 } from "@package/coder-sdk";
@@ -6,6 +7,28 @@ import type { Client } from "@package/coder-sdk/client";
 
 const POLL_INTERVAL_MS = 2000;
 const TIMEOUT_MS = 120_000;
+
+/**
+ * Ensures a Coder user account is in the "active" state.
+ * Coder marks accounts as dormant after a period of inactivity and also
+ * defaults new users to dormant. Since our app abstracts Coder away from
+ * end-users, we must always activate accounts before interacting with them.
+ */
+export async function ensureUserActive(opts: {
+  client: Client;
+  userId: string;
+}) {
+  const resp = await activateUserAccount({
+    client: opts.client,
+    path: { user: opts.userId },
+  });
+
+  if (resp.error) {
+    throw new Error(
+      `Failed to activate Coder user account: ${JSON.stringify(resp.error)}`,
+    );
+  }
+}
 
 /**
  * Starts a Coder workspace if it isn't running and polls until the agent

--- a/packages/backend/convex/web/assignmentActions.ts
+++ b/packages/backend/convex/web/assignmentActions.ts
@@ -3,7 +3,6 @@
 import { v } from "convex/values";
 
 import {
-  activateUserAccount,
   createNewSessionKey,
   createNewUser,
   createUserWorkspace,
@@ -18,7 +17,7 @@ import { createClient } from "@package/coder-sdk/client";
 import { internal } from "../_generated/api";
 import { action } from "../_generated/server";
 import { authComponent } from "../auth";
-import { ensureWorkspaceRunning } from "../helpers/coder";
+import { ensureUserActive, ensureWorkspaceRunning } from "../helpers/coder";
 import { generateDownloadUrl } from "../helpers/minio";
 
 export const launchWorkspace = action({
@@ -87,14 +86,7 @@ export const launchWorkspace = action({
     }
 
     // Activate the user account to ensure they're not dormant
-    const activateResp = await activateUserAccount({
-      client: coderClient,
-      path: { user: coderUserId },
-    });
-
-    if (activateResp.error) {
-      // Don't throw here - continue with workspace launch even if activation fails
-    }
+    await ensureUserActive({ client: coderClient, userId: coderUserId });
 
     // get templates
     const templatesResp = await getTemplatesByOrganization({

--- a/packages/backend/convex/web/submissionActions.ts
+++ b/packages/backend/convex/web/submissionActions.ts
@@ -14,7 +14,7 @@ import type { Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import { action } from "../_generated/server";
 import { authComponent } from "../auth";
-import { ensureWorkspaceRunning } from "../helpers/coder";
+import { ensureUserActive, ensureWorkspaceRunning } from "../helpers/coder";
 import {
   generateDownloadUrl,
   generateUploadUrl,
@@ -138,6 +138,16 @@ export const triggerSubmission = action({
         submissionId,
       });
       throw new Error("Could not find Coder workspace");
+    }
+
+    // Activate the user account to ensure they're not dormant
+    try {
+      await ensureUserActive({ client: coderClient, userId: coderUserId });
+    } catch (err) {
+      await ctx.runMutation(internal.web.submission.internalFailSubmission, {
+        submissionId,
+      });
+      throw err;
     }
 
     try {


### PR DESCRIPTION
Create a helper function that can be wrapped around coder interactions to make sure user account is always active before doing the action