### PR TITLE
feat(web): replace datetime inputs with calendar component for assignment dates

### DIFF
--- a/apps/nextjs/src/app/teacher/classroom/[id]/assignment/new/page.tsx
+++ b/apps/nextjs/src/app/teacher/classroom/[id]/assignment/new/page.tsx
@@ -9,8 +9,10 @@ import { ArrowLeft } from "lucide-react";
 import { toast } from "sonner";
 
 import type { Id } from "@package/backend/convex/_generated/dataModel";
+import type { DateRange } from "@package/ui/calendar";
 import { api } from "@package/backend/convex/_generated/api";
 import { Button } from "@package/ui/button";
+import { Calendar } from "@package/ui/calendar";
 import {
   Card,
   CardContent,
@@ -27,12 +29,6 @@ import { Editor } from "~/components/editor";
 import { StarterCodeUploader } from "~/components/starter-code-uploader";
 import { Authenticated, AuthLoading, Unauthenticated } from "~/lib/auth";
 
-function formatDateForInput(timestamp: number) {
-  const date = new Date(timestamp);
-  const offset = date.getTimezoneOffset() * 60_000;
-  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
-}
-
 function NewAssignmentForm({ classroomId }: { classroomId: Id<"classrooms"> }) {
   const router = useRouter();
   const createAssignment = useMutation(
@@ -48,28 +44,25 @@ function NewAssignmentForm({ classroomId }: { classroomId: Id<"classrooms"> }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [releaseDate, setReleaseDate] = useState(
-    formatDateForInput(Date.now()),
-  );
-  const [dueDate, setDueDate] = useState(
-    formatDateForInput(Date.now() + 24 * 60 * 60 * 1000),
-  );
+  const [dateRange, setDateRange] = useState<DateRange>(defaultDateRange());
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setIsSubmitting(true);
 
     try {
-      const parsedReleaseDate = Date.parse(releaseDate);
-      const parsedDueDate = Date.parse(dueDate);
-
-      if (Number.isNaN(parsedReleaseDate) || Number.isNaN(parsedDueDate)) {
-        throw new Error("Invalid date values");
-      }
-      if (parsedDueDate <= parsedReleaseDate) {
-        throw new Error("Due date must be after release date");
+      if (!dateRange.from || !dateRange.to) {
+        throw new Error("Please select a date range");
       }
       if (!name.trim()) {
         throw new Error("Assignment name is required");
+      }
+
+      const releaseDateVal = new Date(dateRange.from);
+      const dueDateVal = new Date(dateRange.to);
+
+      if (dueDateVal.getTime() <= releaseDateVal.getTime()) {
+        throw new Error("Due date must be after release date");
       }
 
       // Upload starter code first (if any), before creating the assignment
@@ -82,8 +75,8 @@ function NewAssignmentForm({ classroomId }: { classroomId: Id<"classrooms"> }) {
         classroomId,
         name: name.trim(),
         description: description.trim() || undefined,
-        releaseDate: parsedReleaseDate,
-        dueDate: parsedDueDate,
+        releaseDate: releaseDateVal.getTime(),
+        dueDate: dueDateVal.getTime(),
         starterCodeStorageKey: storageKeyRef.current ?? undefined,
       });
 
@@ -134,25 +127,60 @@ function NewAssignmentForm({ classroomId }: { classroomId: Id<"classrooms"> }) {
                 placeholder="Week 3 - Sorting Algorithms"
               />
             </div>
+            <Label aria-label="availability-period">Availability Period</Label>
+            <Calendar
+              className="w-full"
+              mode="range"
+              defaultMonth={dateRange.from}
+              selected={dateRange}
+              onSelect={(newDateRange) =>
+                setDateRange(updateDateRange(dateRange, newDateRange))
+              }
+              numberOfMonths={2}
+              showOutsideDays={false}
+              required
+            />
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <Label htmlFor="release-date">Release Date</Label>
+                <Label htmlFor="release-time">
+                  Availability Start Time / Release Time
+                </Label>
                 <Input
-                  id="release-date"
-                  type="datetime-local"
+                  id="release-time"
+                  type="time"
                   required
-                  value={releaseDate}
-                  onChange={(event) => setReleaseDate(event.target.value)}
+                  // can't figure out a proper way to colour this. Colouring the text
+                  // and background don't work, so we'll settle with inverting the colour
+                  className="[&::-webkit-calendar-picker-indicator]:invert"
+                  value={formatTime(dateRange.from)}
+                  onChange={(event) =>
+                    setDateRange(
+                      updateDateRangeTime(
+                        dateRange,
+                        "from",
+                        event.target.value,
+                      ),
+                    )
+                  }
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="due-date">Due Date</Label>
+                <Label htmlFor="due-time">
+                  Availability End Time / Due Time
+                </Label>
                 <Input
-                  id="due-date"
-                  type="datetime-local"
+                  id="due-time"
+                  type="time"
                   required
-                  value={dueDate}
-                  onChange={(event) => setDueDate(event.target.value)}
+                  // can't figure out a proper way to colour this. Colouring the text
+                  // and background don't work, so we'll settle with inverting the colour
+                  className="[&::-webkit-calendar-picker-indicator]:invert"
+                  value={formatTime(dateRange.to)}
+                  onChange={(event) =>
+                    setDateRange(
+                      updateDateRangeTime(dateRange, "to", event.target.value),
+                    )
+                  }
                 />
               </div>
             </div>
@@ -225,4 +253,68 @@ export default function NewAssignmentPage({
       </AuthLoading>
     </main>
   );
+}
+
+function formatTime(date: Date | undefined) {
+  if (!date) return "";
+  return `${date.getHours().toString().padStart(2, "0")}:${date.getMinutes().toString().padStart(2, "0")}`;
+}
+
+function defaultDateRange() {
+  const from = new Date();
+  const to = new Date(from);
+  to.setDate(to.getDate() + 7);
+  to.setHours(23, 59, 59, 999);
+  return { from, to };
+}
+
+export function updateDateRange(
+  dateRange: DateRange,
+  newDateRange?: DateRange,
+): DateRange {
+  if (!newDateRange) {
+    return dateRange;
+  }
+
+  let newFrom = undefined;
+  if (newDateRange.from) {
+    newFrom = new Date(newDateRange.from);
+    newFrom.setHours(
+      dateRange.from?.getHours() ?? 0,
+      dateRange.from?.getMinutes() ?? 0,
+    );
+  }
+
+  let newTo = undefined;
+  if (newDateRange.to) {
+    newTo = new Date(newDateRange.to);
+    newTo.setHours(
+      dateRange.to?.getHours() ?? 0,
+      dateRange.to?.getMinutes() ?? 0,
+      59,
+      999,
+    );
+  }
+
+  return { from: newFrom, to: newTo };
+}
+
+function updateDateRangeTime(
+  dateRange: DateRange | undefined,
+  field: "from" | "to",
+  time: string,
+) {
+  if (!dateRange) return defaultDateRange();
+  const currentDate = dateRange[field];
+  if (!currentDate) return dateRange;
+  const [hours, minutes] = time.split(":").map(Number) as [number, number];
+  const newDate = new Date(currentDate);
+  newDate.setHours(
+    hours,
+    minutes,
+    field === "to" ? 59 : 0,
+    field === "to" ? 999 : 0,
+  );
+  console.log(newDate);
+  return { ...dateRange, [field]: newDate };
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./button": "./src/button.tsx",
+    "./calendar": "./src/calendar.tsx",
     "./card": "./src/card.tsx",
     "./dialog": "./src/dialog.tsx",
     "./dropdown-menu": "./src/dropdown-menu.tsx",
@@ -16,8 +17,7 @@
     "./spinner": "./src/spinner.tsx",
     "./theme": "./src/theme.tsx",
     "./toast": "./src/toast.tsx",
-    "./input-group": "./src/input-group.tsx",
-    "./dialog": "./src/dialog.tsx"
+    "./input-group": "./src/input-group.tsx"
   },
   "license": "MIT",
   "scripts": {
@@ -35,8 +35,10 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.552.0",
     "radix-ui": "^1.4.3",
+    "react-day-picker": "^9.14.0",
     "react-hook-form": "^7.66.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1"

--- a/packages/ui/src/calendar.tsx
+++ b/packages/ui/src/calendar.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import type { DateRange, DayButton } from "react-day-picker";
+import * as React from "react";
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from "lucide-react";
+import { DayPicker, getDefaultClassNames } from "react-day-picker";
+
+import { cn } from "@package/ui";
+import { Button, buttonVariants } from "@package/ui/button";
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  captionLayout = "label",
+  buttonVariant = "ghost",
+  formatters,
+  components,
+  ...props
+}: React.ComponentProps<typeof DayPicker> & {
+  buttonVariant?: React.ComponentProps<typeof Button>["variant"];
+}) {
+  const defaultClassNames = getDefaultClassNames();
+
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn(
+        "group/calendar bg-background p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+        className,
+      )}
+      captionLayout={captionLayout}
+      formatters={{
+        formatMonthDropdown: (date) =>
+          date.toLocaleString("default", { month: "short" }),
+        ...formatters,
+      }}
+      classNames={{
+        root: cn("w-fit", defaultClassNames.root),
+        months: cn(
+          "relative flex flex-col gap-4 md:flex-row",
+          defaultClassNames.months,
+        ),
+        month: cn("flex w-full flex-col gap-4", defaultClassNames.month),
+        nav: cn(
+          "absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1",
+          defaultClassNames.nav,
+        ),
+        button_previous: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "size-(--cell-size) p-0 select-none aria-disabled:opacity-50",
+          defaultClassNames.button_previous,
+        ),
+        button_next: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "size-(--cell-size) p-0 select-none aria-disabled:opacity-50",
+          defaultClassNames.button_next,
+        ),
+        month_caption: cn(
+          "flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)",
+          defaultClassNames.month_caption,
+        ),
+        dropdowns: cn(
+          "flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium",
+          defaultClassNames.dropdowns,
+        ),
+        dropdown_root: cn(
+          "border-input has-focus:border-ring has-focus:ring-ring/50 relative rounded-md border shadow-xs has-focus:ring-[3px]",
+          defaultClassNames.dropdown_root,
+        ),
+        dropdown: cn(
+          "bg-popover absolute inset-0 opacity-0",
+          defaultClassNames.dropdown,
+        ),
+        caption_label: cn(
+          "font-medium select-none",
+          captionLayout === "label"
+            ? "text-sm"
+            : "[&>svg]:text-muted-foreground flex h-8 items-center gap-1 rounded-md pr-1 pl-2 text-sm [&>svg]:size-3.5",
+          defaultClassNames.caption_label,
+        ),
+        table: "w-full border-collapse",
+        weekdays: cn("flex", defaultClassNames.weekdays),
+        weekday: cn(
+          "text-muted-foreground flex-1 rounded-md text-[0.8rem] font-normal select-none",
+          defaultClassNames.weekday,
+        ),
+        week: cn("mt-2 flex w-full", defaultClassNames.week),
+        week_number_header: cn(
+          "w-(--cell-size) select-none",
+          defaultClassNames.week_number_header,
+        ),
+        week_number: cn(
+          "text-muted-foreground text-[0.8rem] select-none",
+          defaultClassNames.week_number,
+        ),
+        day: cn(
+          "group/day relative aspect-square h-full w-full p-0 text-center select-none [&:last-child[data-selected=true]_button]:rounded-r-md",
+          props.showWeekNumber
+            ? "[&:nth-child(2)[data-selected=true]_button]:rounded-l-md"
+            : "[&:first-child[data-selected=true]_button]:rounded-l-md",
+          defaultClassNames.day,
+        ),
+        range_start: cn(
+          "bg-accent rounded-l-md",
+          defaultClassNames.range_start,
+        ),
+        range_middle: cn("rounded-none", defaultClassNames.range_middle),
+        range_end: cn("bg-accent rounded-r-md", defaultClassNames.range_end),
+        today: cn(
+          "bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none",
+          defaultClassNames.today,
+        ),
+        outside: cn(
+          "text-muted-foreground aria-selected:text-muted-foreground",
+          defaultClassNames.outside,
+        ),
+        disabled: cn(
+          "text-muted-foreground opacity-50",
+          defaultClassNames.disabled,
+        ),
+        hidden: cn("invisible", defaultClassNames.hidden),
+        ...classNames,
+      }}
+      components={{
+        Root: ({ className, rootRef, ...props }) => {
+          return (
+            <div
+              data-slot="calendar"
+              ref={rootRef}
+              className={cn(className)}
+              {...props}
+            />
+          );
+        },
+        Chevron: ({ className, orientation, ...props }) => {
+          if (orientation === "left") {
+            return (
+              <ChevronLeftIcon className={cn("size-4", className)} {...props} />
+            );
+          }
+
+          if (orientation === "right") {
+            return (
+              <ChevronRightIcon
+                className={cn("size-4", className)}
+                {...props}
+              />
+            );
+          }
+
+          return (
+            <ChevronDownIcon className={cn("size-4", className)} {...props} />
+          );
+        },
+        DayButton: CalendarDayButton,
+        WeekNumber: ({ children, ...props }) => {
+          return (
+            <td {...props}>
+              <div className="flex size-(--cell-size) items-center justify-center text-center">
+                {children}
+              </div>
+            </td>
+          );
+        },
+        ...components,
+      }}
+      {...props}
+    />
+  );
+}
+
+function CalendarDayButton({
+  className,
+  day,
+  modifiers,
+  ...props
+}: React.ComponentProps<typeof DayButton>) {
+  const defaultClassNames = getDefaultClassNames();
+
+  const ref = React.useRef<HTMLButtonElement>(null);
+  React.useEffect(() => {
+    if (modifiers.focused) ref.current?.focus();
+  }, [modifiers.focused]);
+
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon"
+      data-day={day.date.toLocaleDateString()}
+      data-selected-single={
+        modifiers.selected &&
+        !modifiers.range_start &&
+        !modifiers.range_end &&
+        !modifiers.range_middle
+      }
+      data-range-start={modifiers.range_start}
+      data-range-end={modifiers.range_end}
+      data-range-middle={modifiers.range_middle}
+      className={cn(
+        "group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground dark:hover:text-accent-foreground flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md [&>span]:text-xs [&>span]:opacity-70",
+        defaultClassNames.day,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Calendar, CalendarDayButton, type DateRange };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -489,12 +489,18 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       lucide-react:
         specifier: ^0.552.0
         version: 0.552.0(react@19.2.0)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-day-picker:
+        specifier: ^9.14.0
+        version: 9.14.0(react@19.2.0)
       react-hook-form:
         specifier: ^7.66.0
         version: 7.66.1(react@19.2.0)
@@ -1078,6 +1084,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@date-fns/tz@1.4.1':
+    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
   '@edge-runtime/primitives@6.0.0':
     resolution: {integrity: sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA==}
@@ -3276,6 +3285,10 @@ packages:
       zod:
         optional: true
 
+  '@tabby_ai/hijri-converter@1.0.5':
+    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
+    engines: {node: '>=16.0.0'}
+
   '@tailwindcss/node@4.1.16':
     resolution: {integrity: sha512-BX5iaSsloNuvKNHRN3k2RcCuTEgASTo77mofW0vmeHkfrDWaoFAFvNHpEgtu0eqyypcyiBkDWzSMxJhp3AUVcw==}
 
@@ -4508,6 +4521,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
@@ -5145,7 +5161,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -6573,6 +6589,12 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
+
+  react-day-picker@9.14.0:
+    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
 
   react-dom@19.2.0:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
@@ -8419,6 +8441,8 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.25': {}
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@date-fns/tz@1.4.1': {}
 
   '@edge-runtime/primitives@6.0.0': {}
 
@@ -10509,6 +10533,8 @@ snapshots:
       valibot: 1.0.0-beta.15(typescript@5.9.3)
       zod: 4.1.12
 
+  '@tabby_ai/hijri-converter@1.0.5': {}
+
   '@tailwindcss/node@4.1.16':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -11868,6 +11894,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns-jalali@4.1.0-0: {}
 
   date-fns@4.1.0: {}
 
@@ -14609,6 +14637,14 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  react-day-picker@9.14.0(react@19.2.0):
+    dependencies:
+      '@date-fns/tz': 1.4.1
+      '@tabby_ai/hijri-converter': 1.0.5
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
+      react: 19.2.0
 
   react-dom@19.2.0(react@19.2.0):
     dependencies:


### PR DESCRIPTION
### TL;DR

Replaced datetime-local inputs with a visual calendar component and separate time inputs for assignment creation

### What changed?

- Added `react-day-picker` dependency to both the Next.js app and UI package
- Created a new `Calendar` component in the UI package with proper styling and date range selection
- Refactored the assignment creation form to use:
  - A visual calendar for date range selection instead of separate datetime-local inputs
  - Separate time inputs for release and due times
  - New helper functions for date/time formatting and manipulation
- Removed the `formatDateForInput` utility function
- Updated form validation to work with the new date range structure

![image.png](https://app.graphite.com/user-attachments/assets/af0a9684-4ad7-48d8-a436-f06be445332a.png)

### How to test?

1. Navigate to the teacher assignment creation page (`/teacher/classroom/[id]/assignment/new`)
2. Verify the calendar displays correctly with two months visible
3. Test selecting a date range by clicking start and end dates
4. Adjust the time inputs for both release and due times
5. Submit the form and ensure dates are properly saved
6. Test validation by trying to set a due date before the release date

### Why make this change?

This improves the user experience by providing a more intuitive visual interface for date selection. The calendar component offers better usability compared to browser-native datetime inputs, which can vary significantly across different browsers and operating systems. The separation of date and time selection also provides more granular control over scheduling assignments.