### PR TITLE
feat(web): replace datetime inputs with date range picker in assignment edit view

### DIFF
--- a/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/page.tsx
+++ b/apps/nextjs/src/app/teacher/classroom/[id]/assignment/[assignmentId]/page.tsx
@@ -18,6 +18,7 @@ import {
 import { toast } from "sonner";
 
 import type { Id } from "@package/backend/convex/_generated/dataModel";
+import type { DateRange } from "@package/ui/calendar";
 import { api } from "@package/backend/convex/_generated/api";
 import { Button } from "@package/ui/button";
 import {
@@ -34,16 +35,14 @@ import { Spinner } from "@package/ui/spinner";
 
 import { getSubmissionDownload } from "~/app/app/actions";
 import { AppDataGrid } from "~/components/app-data-grid";
+import {
+  DatePickerWithRange,
+  defaultDateRange,
+} from "~/components/date-picker-with-range";
 import { Editor } from "~/components/editor";
 import { Authenticated, AuthLoading, Unauthenticated } from "~/lib/auth";
 import { triggerDownload } from "~/lib/download";
 import { StarterCodeCard } from "./starter-code-card";
-
-function formatDateForInput(timestamp: number) {
-  const date = new Date(timestamp);
-  const offset = date.getTimezoneOffset() * 60_000;
-  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
-}
 
 function AssignmentContent({
   classroomId,
@@ -71,8 +70,7 @@ function AssignmentContent({
   interface AssignmentDraft {
     name: NonNullable<UpdateAssignmentArgs["name"]>;
     description: NonNullable<UpdateAssignmentArgs["description"]>;
-    releaseDate: string;
-    dueDate: string;
+    dateRange: DateRange;
   }
 
   const [isEditing, setIsEditing] = useState(false);
@@ -95,8 +93,10 @@ function AssignmentContent({
     setDraft({
       name: assignment.name,
       description: assignment.description ?? "",
-      releaseDate: formatDateForInput(assignment.releaseDate),
-      dueDate: formatDateForInput(assignment.dueDate),
+      dateRange: {
+        from: new Date(assignment.releaseDate),
+        to: new Date(assignment.dueDate),
+      },
     });
     setIsEditing(true);
   };
@@ -120,8 +120,11 @@ function AssignmentContent({
     setIsSavingAssignment(true);
 
     try {
-      const parsedReleaseDate = Date.parse(draft.releaseDate);
-      const parsedDueDate = Date.parse(draft.dueDate);
+      if (!draft.dateRange.from || !draft.dateRange.to) {
+        throw new Error("Please select a date range");
+      }
+      const parsedReleaseDate = draft.dateRange.from.getTime();
+      const parsedDueDate = draft.dateRange.to.getTime();
 
       if (Number.isNaN(parsedReleaseDate) || Number.isNaN(parsedDueDate)) {
         throw new Error("Invalid date values");
@@ -391,30 +394,11 @@ function AssignmentContent({
                       }
                     />
                   </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="assignment-release-date">
-                      Release Date
-                    </Label>
-                    <Input
-                      id="assignment-release-date"
-                      type="datetime-local"
-                      value={draft?.releaseDate ?? ""}
-                      onChange={(event) =>
-                        updateDraft({ releaseDate: event.target.value })
-                      }
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="assignment-due-date">Due Date</Label>
-                    <Input
-                      id="assignment-due-date"
-                      type="datetime-local"
-                      value={draft?.dueDate ?? ""}
-                      onChange={(event) =>
-                        updateDraft({ dueDate: event.target.value })
-                      }
-                    />
-                  </div>
+                  <DatePickerWithRange
+                    date={draft?.dateRange ?? defaultDateRange()}
+                    onDateChange={(dateRange) => updateDraft({ dateRange })}
+                    size="narrow"
+                  />
                   <div className="flex gap-2">
                     <Button
                       className="flex-1"
@@ -450,14 +434,6 @@ function AssignmentContent({
                     </div>
                     <div>
                       <p className="text-muted-foreground text-xs uppercase">
-                        Due Date
-                      </p>
-                      <p className="font-medium">
-                        {new Date(assignment.dueDate).toLocaleString()}
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-muted-foreground text-xs uppercase">
                         Release Date
                       </p>
                       <p className="font-medium">
@@ -466,9 +442,17 @@ function AssignmentContent({
                     </div>
                     <div>
                       <p className="text-muted-foreground text-xs uppercase">
+                        Due Date
+                      </p>
+                      <p className="font-medium">
+                        {new Date(assignment.dueDate).toLocaleString()}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs uppercase">
                         Created
                       </p>
-                      <p className="text-sm">
+                      <p className="font-medium">
                         {new Date(assignment._creationTime).toLocaleString()}
                       </p>
                     </div>

--- a/apps/nextjs/src/components/date-picker-with-range.tsx
+++ b/apps/nextjs/src/components/date-picker-with-range.tsx
@@ -1,39 +1,47 @@
 "use client";
 
 import type { DateRange } from "@package/ui/calendar";
+import { cn } from "@package/ui";
 import { Calendar } from "@package/ui/calendar";
 import { Input } from "@package/ui/input";
 import { Label } from "@package/ui/label";
+
+type DatePickerSize = "wide" | "narrow";
 
 export function DatePickerWithRange({
   className,
   date,
   onDateChange,
   required,
+  size = "wide",
 }: {
   className?: string;
   date: DateRange;
   onDateChange: (dateRange: DateRange) => void;
   required?: boolean;
+  size?: DatePickerSize;
 }) {
+  const numberOfMonths = size === "narrow" ? 1 : 2;
+  const gridCols = size === "narrow" ? "grid-cols-1" : "md:grid-cols-2";
+
   return (
-    <div className={className}>
+    <div className={cn("space-y-4", className)}>
       <Label aria-label="availability-period">Availability Period</Label>
       <Calendar
-        className="w-full"
+        className="w-full p-0"
         mode="range"
         defaultMonth={date.from}
         selected={date}
         onSelect={(newDateRange: DateRange | undefined) =>
           onDateChange(updateDateRange(date, newDateRange))
         }
-        numberOfMonths={2}
+        numberOfMonths={numberOfMonths}
         showOutsideDays={false}
         required={required}
       />
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className={cn("grid gap-4", gridCols)}>
         <div className="space-y-2">
-          <Label htmlFor="release-time">Start Time</Label>
+          <Label htmlFor="release-time">Release Time</Label>
           <Input
             id="release-time"
             type="time"
@@ -50,7 +58,7 @@ export function DatePickerWithRange({
           />
         </div>
         <div className="space-y-2">
-          <Label htmlFor="due-time">End Time</Label>
+          <Label htmlFor="due-time">Due Time</Label>
           <Input
             id="due-time"
             type="time"


### PR DESCRIPTION
### TL;DR

Replaced separate datetime-local inputs with a unified date range picker component for assignment release and due dates.

### What changed?

![image.png](https://app.graphite.com/user-attachments/assets/9795851d-909f-4569-938c-808aa91a4865.png)

view mode remains the same:
![image.png](https://app.graphite.com/user-attachments/assets/088b7c48-6191-4ea4-95cd-544bb4376404.png)

- Removed individual datetime-local inputs for release date and due date
- Integrated the `DatePickerWithRange` component for date selection
- Updated the assignment draft interface to use a `DateRange` object instead of separate date strings
- Removed the `formatDateForInput` utility function
- Enhanced the `DatePickerWithRange` component with a `size` prop to support narrow layouts
- Fixed the display order of release date and due date in the assignment details view
- Improved date validation to check for complete date range selection

### How to test?

1. Navigate to a teacher's assignment page
2. Click the edit button to modify an assignment
3. Verify the new date range picker displays correctly with calendar and time inputs
4. Test selecting different date ranges and times
5. Save the assignment and confirm dates are preserved correctly
6. Check that the assignment details view shows release and due dates in the correct order

### Why make this change?

This change provides a more intuitive and consistent user experience for date selection by replacing separate datetime inputs with a visual calendar interface. The unified date range picker makes it clearer that users are selecting a period with start and end dates, reducing potential confusion and input errors.

solves #266